### PR TITLE
Add a random element in the payload to prevent Signature reuse

### DIFF
--- a/transloadit.go
+++ b/transloadit.go
@@ -99,6 +99,8 @@ func (client *Client) sign(params map[string]interface{}) (string, string, error
 		Key:     client.config.AuthKey,
 		Expires: getExpireString(),
 	}
+	// Add a random nonce to make signatures unique and prevent error about
+	// signature reuse: https://github.com/transloadit/go-sdk/pull/35
 	params["nonce"] = rand.Int()
 	b, err := json.Marshal(params)
 	if err != nil {

--- a/transloadit.go
+++ b/transloadit.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"math/rand"
 	"net/http"
 	"net/url"
 	"strings"
@@ -98,7 +99,7 @@ func (client *Client) sign(params map[string]interface{}) (string, string, error
 		Key:     client.config.AuthKey,
 		Expires: getExpireString(),
 	}
-
+	params["nonce"] = rand.Int()
 	b, err := json.Marshal(params)
 	if err != nil {
 		return "", "", fmt.Errorf("unable to create signature: %s", err)


### PR DESCRIPTION
Prevent message like  "request failed due to SIGNATURE_REUSE_DETECTED: The request was denied for security reasons. If you think this is in error, please get in touch with support." which is due to the fact that request in the same second without payload will have the same signature