### PR TITLE
Use sha384 signatures for list requests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
 SHELL := /usr/bin/env bash
 
 test-examples:
-	cd ./examples && find . -type f | xargs -i sh -c "go build {} && go clean" \;
+	tmp=$$(mktemp -d); \
+	trap 'rm -rf "$$tmp"' EXIT; \
+	while IFS= read -r -d '' file; do \
+		go build -o "$$tmp/$$(basename "$$(dirname "$$file")")" "$$file"; \
+	done < <(find ./examples -name '*.go' -print0)
 
 test-package:
 	go test -v -coverprofile=coverage.out -covermode=atomic .
@@ -20,5 +24,5 @@ release:
 .PHONY: \
 	release \
 	test \
-  test-package \
-  test-examples
+	test-package \
+	test-examples

--- a/transloadit.go
+++ b/transloadit.go
@@ -4,7 +4,6 @@ package transloadit
 import (
 	"context"
 	"crypto/hmac"
-	"crypto/sha1"
 	"crypto/sha256"
 	"crypto/sha512"
 	"encoding/hex"
@@ -213,11 +212,11 @@ func (client *Client) listRequest(ctx context.Context, path string, listOptions 
 		return fmt.Errorf("unable to create signature: %s", err)
 	}
 
-	hash := hmac.New(sha1.New, []byte(client.config.AuthSecret))
+	hash := hmac.New(sha512.New384, []byte(client.config.AuthSecret))
 	hash.Write(b)
 
 	params := string(b)
-	signature := hex.EncodeToString(hash.Sum(nil))
+	signature := "sha384:" + hex.EncodeToString(hash.Sum(nil))
 
 	v := url.Values{}
 	v.Set("params", params)

--- a/transloadit.go
+++ b/transloadit.go
@@ -293,7 +293,7 @@ func (client *Client) CreateSignedSmartCDNUrl(opts SignedSmartCDNUrlOptions) str
 
 	stringToSign := fmt.Sprintf("%s/%s/%s?%s", workspaceSlug, templateSlug, inputField, queryString)
 
-	// Create signature using SHA-256
+	// Smart CDN signatures intentionally remain SHA-256; API request signatures use SHA-384.
 	hash := hmac.New(sha256.New, []byte(client.config.AuthSecret))
 	hash.Write([]byte(stringToSign))
 	signature := url.QueryEscape("sha256:" + hex.EncodeToString(hash.Sum(nil)))

--- a/transloadit_signature_test.go
+++ b/transloadit_signature_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/hmac"
 	"crypto/sha512"
 	"encoding/hex"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -44,16 +45,24 @@ func TestListRequest_UsesSha384WithAlgorithmPrefix(t *testing.T) {
 		AuthSecret: "foo_secret",
 	})
 
+	errCh := make(chan error, 1)
+	reportErr := func(err error) {
+		select {
+		case errCh <- err:
+		default:
+		}
+	}
+
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		params := r.URL.Query().Get("params")
 		signature := r.URL.Query().Get("signature")
 
 		if params == "" {
-			t.Fatal("params query should be set")
+			reportErr(fmt.Errorf("params query should be set"))
 		}
 
 		if !strings.HasPrefix(signature, "sha384:") {
-			t.Fatalf("listRequest signature prefix should be sha384:, got %q", signature)
+			reportErr(fmt.Errorf("listRequest signature prefix should be sha384:, got %q", signature))
 		}
 
 		hash := hmac.New(sha512.New384, []byte(client.config.AuthSecret))
@@ -61,7 +70,7 @@ func TestListRequest_UsesSha384WithAlgorithmPrefix(t *testing.T) {
 		expected := "sha384:" + hex.EncodeToString(hash.Sum(nil))
 
 		if signature != expected {
-			t.Fatalf("wrong listRequest signature, expected %q got %q", expected, signature)
+			reportErr(fmt.Errorf("wrong listRequest signature, expected %q got %q", expected, signature))
 		}
 
 		w.Header().Set("Content-Type", "application/json")
@@ -78,5 +87,11 @@ func TestListRequest_UsesSha384WithAlgorithmPrefix(t *testing.T) {
 
 	if list.Count != 0 {
 		t.Fatalf("expected empty list count 0, got %d", list.Count)
+	}
+
+	select {
+	case verifyErr := <-errCh:
+		t.Fatal(verifyErr)
+	default:
 	}
 }

--- a/transloadit_signature_test.go
+++ b/transloadit_signature_test.go
@@ -1,0 +1,82 @@
+package transloadit
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha512"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestSign_UsesSha384WithAlgorithmPrefix(t *testing.T) {
+	client := NewClient(Config{
+		AuthKey:    "foo_key",
+		AuthSecret: "foo_secret",
+		Endpoint:   "https://api2.transloadit.com",
+	})
+
+	params, signature, err := client.sign(map[string]interface{}{
+		"foo": "bar",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.HasPrefix(signature, "sha384:") {
+		t.Fatalf("signature prefix should be sha384:, got %q", signature)
+	}
+
+	hash := hmac.New(sha512.New384, []byte(client.config.AuthSecret))
+	hash.Write([]byte(params))
+	expected := "sha384:" + hex.EncodeToString(hash.Sum(nil))
+
+	if signature != expected {
+		t.Fatalf("wrong signature, expected %q got %q", expected, signature)
+	}
+}
+
+func TestListRequest_UsesSha384WithAlgorithmPrefix(t *testing.T) {
+	client := NewClient(Config{
+		AuthKey:    "foo_key",
+		AuthSecret: "foo_secret",
+	})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		params := r.URL.Query().Get("params")
+		signature := r.URL.Query().Get("signature")
+
+		if params == "" {
+			t.Fatal("params query should be set")
+		}
+
+		if !strings.HasPrefix(signature, "sha384:") {
+			t.Fatalf("listRequest signature prefix should be sha384:, got %q", signature)
+		}
+
+		hash := hmac.New(sha512.New384, []byte(client.config.AuthSecret))
+		hash.Write([]byte(params))
+		expected := "sha384:" + hex.EncodeToString(hash.Sum(nil))
+
+		if signature != expected {
+			t.Fatalf("wrong listRequest signature, expected %q got %q", expected, signature)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"items":[],"count":0}`))
+	}))
+	defer server.Close()
+
+	client.config.Endpoint = server.URL
+
+	list, err := client.ListTemplates(context.Background(), &ListOptions{PageSize: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if list.Count != 0 {
+		t.Fatalf("expected empty list count 0, got %d", list.Count)
+	}
+}


### PR DESCRIPTION
## Summary
- switch `listRequest()` signature generation from SHA-1 to SHA-384
- include the `sha384:` algorithm prefix for list-request signatures
- add regression tests for:
  - `sign()` uses sha384 with prefix
  - `listRequest()` uses sha384 with prefix

## Why
`api2` issue https://github.com/transloadit/api2/issues/5337 tracks SDK support for SHA-384 signatures.

The Go SDK already used SHA-384 for normal request signing, but `listRequest()` still used SHA-1 without a prefix. This made signature behavior inconsistent and could break accounts defaulting to SHA-384.

## Notes
- Smart CDN signing remains unchanged (SHA-256).
