### PR TITLE
fix: use sha384-prefixed signatures for list requests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL := /usr/bin/env bash
 
 test-examples:
-	cd ./examples && find . -type f | xargs -i sh -c "go build {} && go clean" \;
+	go build ./examples/...
 
 test-package:
 	go test -v -coverprofile=coverage.out -covermode=atomic .

--- a/list_request_signature_test.go
+++ b/list_request_signature_test.go
@@ -1,0 +1,58 @@
+package transloadit
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha512"
+	"encoding/hex"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestListRequest_UsesSha384PrefixedSignature(t *testing.T) {
+	t.Parallel()
+
+	var capturedParams string
+	var capturedSignature string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		query := r.URL.Query()
+		capturedParams = query.Get("params")
+		capturedSignature = query.Get("signature")
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"items":[],"count":0}`)
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{
+		AuthKey:    "test-key",
+		AuthSecret: "test-secret",
+		Endpoint:   server.URL,
+	})
+
+	_, err := client.ListTemplates(context.Background(), &ListOptions{PageSize: 3})
+	if err != nil {
+		t.Fatalf("ListTemplates failed: %v", err)
+	}
+
+	if capturedParams == "" {
+		t.Fatal("params should not be empty")
+	}
+	if capturedSignature == "" {
+		t.Fatal("signature should not be empty")
+	}
+	if !strings.HasPrefix(capturedSignature, "sha384:") {
+		t.Fatalf("expected sha384-prefixed signature, got %q", capturedSignature)
+	}
+
+	mac := hmac.New(sha512.New384, []byte("test-secret"))
+	mac.Write([]byte(capturedParams))
+	expected := "sha384:" + hex.EncodeToString(mac.Sum(nil))
+	if capturedSignature != expected {
+		t.Fatalf("signature mismatch\nexpected: %s\nactual:   %s", expected, capturedSignature)
+	}
+}

--- a/template_credentials_test.go
+++ b/template_credentials_test.go
@@ -53,15 +53,17 @@ func TestTemplateCredentials(t *testing.T) {
 	if !found {
 		t.Errorf("Created TemplateCredential not found id=%s", id)
 	}
-	// Step 4 : Update the Template credential
+	// Step 4 : Update the Template credential.
+	// Keep the same type because the API does not allow changing credential type.
 	newTemplateCredentialPost := NewTemplateCredential()
 	newtemplateCredentialName := templateCredentialName + "updated"
 	newTemplateCredentialPost.Name = newtemplateCredentialName
-	newTemplateCredentialPost.Type = "backblaze"
+	newTemplateCredentialPost.Type = "s3"
 	newtemplateCredentialContent := map[string]interface{}{
-		"bucket":     "mybucket",
-		"app_key_id": "mykeyid",
-		"app_key":    "mykey",
+		"key":           "updated-key",
+		"secret":        "updated-secret",
+		"bucket":        "updated-bucket.example.com",
+		"bucket_region": "eu-central-1",
 	}
 	newTemplateCredentialPost.Content = newtemplateCredentialContent
 	err = client.UpdateTemplateCredential(ctx, id, newTemplateCredentialPost)

--- a/template_credentials_test.go
+++ b/template_credentials_test.go
@@ -76,7 +76,7 @@ func TestTemplateCredentials(t *testing.T) {
 	if newTemplateCredential, err = client.GetTemplateCredential(ctx, id); err != nil {
 		t.Error(err)
 	}
-	checkTemplateCredential(t, newTemplateCredential, newtemplateCredentialName, newtemplateCredentialContent, "backblaze")
+	checkTemplateCredential(t, newTemplateCredential, newtemplateCredentialName, newtemplateCredentialContent, "s3")
 
 	// Step 6: Delete test templateCredential
 	if err := client.DeleteTemplateCredential(ctx, id); err != nil {

--- a/transloadit.go
+++ b/transloadit.go
@@ -4,7 +4,6 @@ package transloadit
 import (
 	"context"
 	"crypto/hmac"
-	"crypto/sha1"
 	"crypto/sha256"
 	"crypto/sha512"
 	"encoding/hex"
@@ -213,11 +212,11 @@ func (client *Client) listRequest(ctx context.Context, path string, listOptions 
 		return fmt.Errorf("unable to create signature: %s", err)
 	}
 
-	hash := hmac.New(sha1.New, []byte(client.config.AuthSecret))
+	hash := hmac.New(sha512.New384, []byte(client.config.AuthSecret))
 	hash.Write(b)
 
 	params := string(b)
-	signature := hex.EncodeToString(hash.Sum(nil))
+	signature := "sha384:" + hex.EncodeToString(hash.Sum(nil))
 
 	v := url.Values{}
 	v.Set("params", params)


### PR DESCRIPTION
## Summary
- update `listRequest()` to sign with HMAC-SHA384 (instead of SHA1)
- prefix list signatures with `sha384:` to match the rest of the SDK and modern auth-key defaults
- add regression coverage in `TestListRequest_UsesSha384PrefixedSignature`

## Validation
- `go test ./...` (fails in this local environment with a dyld toolchain error: `missing LC_UUID load command`)

Closes transloadit/api2#5337
