### PR TITLE
Refresh Go CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,14 +13,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go_version: ['1.11', '1.12', '1.13', '1.14', '1.15', '1.16', '1.17', '1.18', '1.19', '1.20', '1.21', '1.22', '1.23', '1.24']
+        go_version: ['1.15', '1.20', '1.24', '1.25', '1.26']
         os: [ubuntu-latest]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
 
     - name: Set up Go ${{ matrix.go_version }}
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v6
       with:
         go-version: ${{ matrix.go_version }}
 
@@ -31,7 +31,7 @@ jobs:
         TRANSLOADIT_SECRET: ${{ secrets.TRANSLOADIT_SECRET }}
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v6
       with:
         fail_ci_if_error: true
         files: ./coverage.out


### PR DESCRIPTION
Why:
The SDK CI matrix should keep the declared runtime floor visible while still testing current Go releases. The existing matrix exhaustively tested old Go versions through 1.24, but did not include the current stable Go release.

What:
- Collapse the matrix to a representative spread: Go 1.15, 1.20, 1.24, 1.25, and 1.26.
- Keep the declared go.mod floor covered.
- Update checkout, setup-go, and Codecov actions to current majors so CI can resolve newer Go versions reliably and avoid stale action runtimes.

Validation:
- go test ./... (with TRANSLOADIT_KEY and TRANSLOADIT_SECRET from ~/code/node-sdk/.env)
- go test ./examples/...
- git diff --check

Migration notes:
- actions/checkout@v6, actions/setup-go@v6, and codecov/codecov-action@v6 use newer Node runtimes. This workflow runs on GitHub-hosted ubuntu-latest runners, which satisfy the runner requirements.