### PR TITLE
Generated endpoint markers and devdock examples

### DIFF
--- a/api2_generated_models_test.go
+++ b/api2_generated_models_test.go
@@ -1,0 +1,44 @@
+package transloadit
+
+// This file is generated from Transloadit API2 contracts. If it looks wrong,
+// please report the issue instead of editing this file by hand; the source fix
+// belongs in the contract generator so all SDKs stay in sync.
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestGeneratedApi2ContractModelFields(t *testing.T) {
+	assertGeneratedApi2ContractModelField(t, reflect.TypeOf(AssemblyInfo{}), "AssemblyID", "assembly_id", reflect.TypeOf((*string)(nil)).Elem())
+	assertGeneratedApi2ContractModelField(t, reflect.TypeOf(AssemblyInfo{}), "AssemblySSLURL", "assembly_ssl_url", reflect.TypeOf((*string)(nil)).Elem())
+	assertGeneratedApi2ContractModelField(t, reflect.TypeOf(AssemblyInfo{}), "AssemblyURL", "assembly_url", reflect.TypeOf((*string)(nil)).Elem())
+	assertGeneratedApi2ContractModelField(t, reflect.TypeOf(AssemblyInfo{}), "Error", "error", reflect.TypeOf((*string)(nil)).Elem())
+	assertGeneratedApi2ContractModelField(t, reflect.TypeOf(AssemblyInfo{}), "Ok", "ok", reflect.TypeOf((*string)(nil)).Elem())
+	assertGeneratedApi2ContractModelField(t, reflect.TypeOf(AssemblyInfo{}), "Results", "results", reflect.TypeOf((*map[string][]*FileInfo)(nil)).Elem())
+	assertGeneratedApi2ContractModelField(t, reflect.TypeOf(AssemblyInfo{}), "TUSURL", "tus_url", reflect.TypeOf((*string)(nil)).Elem())
+	assertGeneratedApi2ContractModelField(t, reflect.TypeOf(AssemblyInfo{}), "Uploads", "uploads", reflect.TypeOf((*[]*FileInfo)(nil)).Elem())
+	assertGeneratedApi2ContractModelField(t, reflect.TypeOf(FileInfo{}), "Field", "field", reflect.TypeOf((*string)(nil)).Elem())
+	assertGeneratedApi2ContractModelField(t, reflect.TypeOf(FileInfo{}), "IsTUSFile", "is_tus_file", reflect.TypeOf((*bool)(nil)).Elem())
+	assertGeneratedApi2ContractModelField(t, reflect.TypeOf(FileInfo{}), "Name", "name", reflect.TypeOf((*string)(nil)).Elem())
+	assertGeneratedApi2ContractModelField(t, reflect.TypeOf(FileInfo{}), "TUSUploadURL", "tus_upload_url", reflect.TypeOf((*string)(nil)).Elem())
+	assertGeneratedApi2ContractModelField(t, reflect.TypeOf(FileInfo{}), "UserMeta", "user_meta", reflect.TypeOf((*map[string]interface{})(nil)).Elem())
+}
+
+func assertGeneratedApi2ContractModelField(t *testing.T, modelType reflect.Type, fieldName string, jsonField string, expectedType reflect.Type) {
+	t.Helper()
+
+	field, ok := modelType.FieldByName(fieldName)
+	if !ok {
+		t.Fatalf("%s.%s is missing", modelType.Name(), fieldName)
+	}
+	if field.Type != expectedType {
+		t.Fatalf("%s.%s has type %s, expected %s", modelType.Name(), fieldName, field.Type, expectedType)
+	}
+
+	jsonTag := field.Tag.Get("json")
+	if jsonTag != jsonField && !strings.HasPrefix(jsonTag, jsonField+",") {
+		t.Fatalf("%s.%s has json tag %q, expected %q", modelType.Name(), fieldName, jsonTag, jsonField)
+	}
+}

--- a/api2_generated_path.go
+++ b/api2_generated_path.go
@@ -4,7 +4,18 @@ package transloadit
 // please report the issue instead of editing this file by hand; the source fix
 // belongs in the contract generator so all SDKs stay in sync.
 
-import "net/url"
+import (
+	"errors"
+	"net/url"
+)
+
+func validatePathSegment(value string) error {
+	if value == "." || value == ".." {
+		return errors.New("path parameters cannot be dot segments")
+	}
+
+	return nil
+}
 
 func escapePathSegment(value string) string {
 	return url.PathEscape(value)

--- a/api2_generated_path.go
+++ b/api2_generated_path.go
@@ -1,0 +1,11 @@
+package transloadit
+
+// This file is generated from Transloadit API2 contracts. If it looks wrong,
+// please report the issue instead of editing this file by hand; the source fix
+// belongs in the contract generator so all SDKs stay in sync.
+
+import "net/url"
+
+func escapePathSegment(value string) string {
+	return url.PathEscape(value)
+}

--- a/assembly.go
+++ b/assembly.go
@@ -307,6 +307,7 @@ func (assembly *Assembly) makeRequest(ctx context.Context, client *Client) (*htt
 }
 
 // <api2-generated-endpoint getAssemblyStatus>
+
 // GetAssembly fetches the full assembly status from the provided URL.
 // The assembly URL must be absolute, for example:
 // https://api2-amberly.transloadit.com/assemblies/15a6b3701d3811e78d7bfba4db1b053e
@@ -320,6 +321,7 @@ func (client *Client) GetAssembly(ctx context.Context, assemblyURL string) (*Ass
 // </api2-generated-endpoint getAssemblyStatus>
 
 // <api2-generated-endpoint cancelAssembly>
+
 // CancelAssembly cancels an assembly which will result in all corresponding
 // uploads and encoding jobs to be aborted. Finally, the updated assembly
 // information after the cancellation will be returned.
@@ -382,6 +384,7 @@ func (client *Client) StartAssemblyReplay(ctx context.Context, assembly Assembly
 }
 
 // <api2-generated-endpoint listAssemblies>
+
 // ListAssemblies will fetch all assemblies matching the provided criteria.
 func (client *Client) ListAssemblies(ctx context.Context, options *ListOptions) (AssemblyList, error) {
 	var assemblies AssemblyList

--- a/assembly.go
+++ b/assembly.go
@@ -308,6 +308,10 @@ func (assembly *Assembly) makeRequest(ctx context.Context, client *Client) (*htt
 
 // <api2-generated-endpoint getAssemblyStatus>
 
+// This block is generated from Transloadit API2 contracts. If it looks wrong,
+// please report the issue instead of editing this block by hand; the source fix
+// belongs in the contract generator so all SDKs stay in sync.
+
 // GetAssembly fetches the full assembly status from the provided URL.
 // The assembly URL must be absolute, for example:
 // https://api2-amberly.transloadit.com/assemblies/15a6b3701d3811e78d7bfba4db1b053e
@@ -321,6 +325,10 @@ func (client *Client) GetAssembly(ctx context.Context, assemblyURL string) (*Ass
 // </api2-generated-endpoint getAssemblyStatus>
 
 // <api2-generated-endpoint cancelAssembly>
+
+// This block is generated from Transloadit API2 contracts. If it looks wrong,
+// please report the issue instead of editing this block by hand; the source fix
+// belongs in the contract generator so all SDKs stay in sync.
 
 // CancelAssembly cancels an assembly which will result in all corresponding
 // uploads and encoding jobs to be aborted. Finally, the updated assembly
@@ -384,6 +392,10 @@ func (client *Client) StartAssemblyReplay(ctx context.Context, assembly Assembly
 }
 
 // <api2-generated-endpoint listAssemblies>
+
+// This block is generated from Transloadit API2 contracts. If it looks wrong,
+// please report the issue instead of editing this block by hand; the source fix
+// belongs in the contract generator so all SDKs stay in sync.
 
 // ListAssemblies will fetch all assemblies matching the provided criteria.
 func (client *Client) ListAssemblies(ctx context.Context, options *ListOptions) (AssemblyList, error) {

--- a/assembly.go
+++ b/assembly.go
@@ -306,6 +306,7 @@ func (assembly *Assembly) makeRequest(ctx context.Context, client *Client) (*htt
 	return req, nil
 }
 
+// <api2-generated-endpoint getAssemblyStatus>
 // GetAssembly fetches the full assembly status from the provided URL.
 // The assembly URL must be absolute, for example:
 // https://api2-amberly.transloadit.com/assemblies/15a6b3701d3811e78d7bfba4db1b053e
@@ -316,6 +317,9 @@ func (client *Client) GetAssembly(ctx context.Context, assemblyURL string) (*Ass
 	return &info, err
 }
 
+// </api2-generated-endpoint getAssemblyStatus>
+
+// <api2-generated-endpoint cancelAssembly>
 // CancelAssembly cancels an assembly which will result in all corresponding
 // uploads and encoding jobs to be aborted. Finally, the updated assembly
 // information after the cancellation will be returned.
@@ -327,6 +331,8 @@ func (client *Client) CancelAssembly(ctx context.Context, assemblyURL string) (*
 
 	return &info, err
 }
+
+// </api2-generated-endpoint cancelAssembly>
 
 // NewAssemblyReplay will create a new AssemblyReplay struct which can be used
 // to replay an assemblie's execution using Client.StartAssemblyReplay.
@@ -375,6 +381,7 @@ func (client *Client) StartAssemblyReplay(ctx context.Context, assembly Assembly
 	return &info, nil
 }
 
+// <api2-generated-endpoint listAssemblies>
 // ListAssemblies will fetch all assemblies matching the provided criteria.
 func (client *Client) ListAssemblies(ctx context.Context, options *ListOptions) (AssemblyList, error) {
 	var assemblies AssemblyList
@@ -382,3 +389,5 @@ func (client *Client) ListAssemblies(ctx context.Context, options *ListOptions) 
 
 	return assemblies, err
 }
+
+// </api2-generated-endpoint listAssemblies>

--- a/assembly.go
+++ b/assembly.go
@@ -271,6 +271,76 @@ func (client *Client) CreateTusAssembly(ctx context.Context, fileCount int) (*As
 
 // </api2-generated-feature createTusAssembly>
 
+// <api2-generated-feature resumeTusUpload>
+
+// This block is generated from Transloadit API2 contracts. If it looks wrong,
+// please report the issue instead of editing this block by hand; the source fix
+// belongs in the contract generator so all SDKs stay in sync.
+
+// ResumeTusUpload resumes an interrupted TUS upload from the server-reported offset and waits for the Assembly to finish.
+func (client *Client) ResumeTusUpload(ctx context.Context, uploadUrl string, content []byte, assembly *AssemblyInfo) (*AssemblyInfo, error) {
+	storedUploadURL, err := url.Parse(uploadUrl)
+	if err != nil {
+		return nil, err
+	}
+
+	offsetRequest, err := http.NewRequestWithContext(ctx, "HEAD", storedUploadURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	offsetRequest.Header.Set("Tus-Resumable", "1.0.0")
+
+	offsetResponse, err := client.httpClient.Do(offsetRequest)
+	if err != nil {
+		return nil, err
+	}
+	defer offsetResponse.Body.Close()
+	if offsetResponse.StatusCode != 200 {
+		return nil, fmt.Errorf("TUS offset returned HTTP %d, expected 200", offsetResponse.StatusCode)
+	}
+	resumeOffsetHeader := offsetResponse.Header.Get("Upload-Offset")
+	if resumeOffsetHeader == "" {
+		return nil, fmt.Errorf("TUS offset did not return a Upload-Offset header")
+	}
+	resumeOffset, err := strconv.Atoi(resumeOffsetHeader)
+	if err != nil {
+		return nil, fmt.Errorf("TUS offset returned an invalid Upload-Offset header")
+	}
+
+	uploadRequest, err := http.NewRequestWithContext(ctx, "PATCH", storedUploadURL.String(), bytes.NewReader(content[resumeOffset:]))
+	if err != nil {
+		return nil, err
+	}
+	uploadRequest.Header.Set("Tus-Resumable", "1.0.0")
+	uploadRequest.Header.Set("Upload-Offset", strconv.Itoa(resumeOffset))
+	uploadRequest.Header.Set("Content-Type", "application/offset+octet-stream")
+
+	uploadResponse, err := client.httpClient.Do(uploadRequest)
+	if err != nil {
+		return nil, err
+	}
+	defer uploadResponse.Body.Close()
+	if uploadResponse.StatusCode != 204 {
+		return nil, fmt.Errorf("TUS upload returned HTTP %d, expected 204", uploadResponse.StatusCode)
+	}
+	uploadOffset, err := strconv.Atoi(uploadResponse.Header.Get("Upload-Offset"))
+	if err != nil {
+		return nil, err
+	}
+	if uploadOffset != len(content) {
+		return nil, fmt.Errorf("TUS upload offset %d, expected %d", uploadOffset, len(content))
+	}
+
+	completedAssembly, err := client.WaitForAssembly(ctx, assembly)
+	if err != nil {
+		return nil, err
+	}
+
+	return completedAssembly, nil
+}
+
+// </api2-generated-feature resumeTusUpload>
+
 // <api2-generated-feature uploadTusAssembly>
 
 // This block is generated from Transloadit API2 contracts. If it looks wrong,

--- a/assembly.go
+++ b/assembly.go
@@ -351,6 +351,10 @@ func (client *Client) UploadTusAssembly(ctx context.Context, fileCount int, cont
 		return nil, "", fmt.Errorf("TUS upload offset %d, expected %d", uploadOffset, len(content))
 	}
 
+	createdAssemblyAssemblySSLURL := createdAssembly.AssemblySSLURL
+	if createdAssemblyAssemblySSLURL == "" {
+		return nil, "", fmt.Errorf("uploadTusAssembly needs createdAssembly.assembly_ssl_url")
+	}
 	completedAssembly, err := client.WaitForAssembly(ctx, createdAssembly)
 	if err != nil {
 		return nil, "", err

--- a/assembly.go
+++ b/assembly.go
@@ -293,7 +293,7 @@ func (client *Client) UploadTusAssembly(ctx context.Context, fileCount int, cont
 	for name, value := range userMeta {
 		metadataMap[name] = value
 	}
-	metadataMap["assembly_url"] = createdAssembly.AssemblyURL
+	metadataMap["assembly_url"] = createdAssembly.AssemblySSLURL
 	metadataMap["fieldname"] = fieldname
 	metadataMap["filename"] = filename
 

--- a/assembly.go
+++ b/assembly.go
@@ -348,8 +348,8 @@ func (client *Client) ResumeTusUpload(ctx context.Context, uploadUrl string, con
 // belongs in the contract generator so all SDKs stay in sync.
 
 // UploadTusAssembly creates a TUS-ready Assembly, uploads one file with the TUS protocol, and waits for the Assembly to finish.
-func (client *Client) UploadTusAssembly(ctx context.Context, fileCount int, content []byte, fieldname string, filename string, userMeta map[string]string) (*AssemblyInfo, string, error) {
-	createdAssembly, err := client.CreateTusAssembly(ctx, fileCount)
+func (client *Client) UploadTusAssembly(ctx context.Context, content []byte, fieldname string, filename string, userMeta map[string]string) (*AssemblyInfo, string, error) {
+	createdAssembly, err := client.CreateTusAssembly(ctx, 1)
 	if err != nil {
 		return nil, "", err
 	}

--- a/assembly.go
+++ b/assembly.go
@@ -1,13 +1,17 @@
 package transloadit
 
 import (
+	"bytes"
 	"context"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"mime/multipart"
 	"net/http"
+	"net/url"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -266,6 +270,96 @@ func (client *Client) CreateTusAssembly(ctx context.Context, fileCount int) (*As
 }
 
 // </api2-generated-feature createTusAssembly>
+
+// <api2-generated-feature uploadTusAssembly>
+
+// This block is generated from Transloadit API2 contracts. If it looks wrong,
+// please report the issue instead of editing this block by hand; the source fix
+// belongs in the contract generator so all SDKs stay in sync.
+
+// UploadTusAssembly creates a TUS-ready Assembly, uploads one file with the TUS protocol, and waits for the Assembly to finish.
+func (client *Client) UploadTusAssembly(ctx context.Context, fileCount int, content []byte, fieldname string, filename string, userMeta map[string]string) (*AssemblyInfo, string, error) {
+	createdAssembly, err := client.CreateTusAssembly(ctx, fileCount)
+	if err != nil {
+		return nil, "", err
+	}
+
+	endpointURL, err := url.Parse(createdAssembly.TUSURL)
+	if err != nil {
+		return nil, "", err
+	}
+
+	uploadMetadata := make(map[string]string)
+	for name, value := range userMeta {
+		uploadMetadata[name] = value
+	}
+	uploadMetadata["assembly_url"] = createdAssembly.AssemblyURL
+	uploadMetadata["fieldname"] = fieldname
+	uploadMetadata["filename"] = filename
+
+	createRequest, err := http.NewRequestWithContext(ctx, "POST", endpointURL.String(), nil)
+	if err != nil {
+		return nil, "", err
+	}
+	createRequest.Header.Set("Tus-Resumable", "1.0.0")
+	createRequest.Header.Set("Upload-Length", strconv.Itoa(len(content)))
+	metadataParts := make([]string, 0, len(uploadMetadata))
+	for name, value := range uploadMetadata {
+		metadataParts = append(metadataParts, fmt.Sprintf("%s %s", name, base64.StdEncoding.EncodeToString([]byte(value))))
+	}
+	createRequest.Header.Set("Upload-Metadata", strings.Join(metadataParts, ","))
+
+	createResponse, err := client.httpClient.Do(createRequest)
+	if err != nil {
+		return nil, "", err
+	}
+	defer createResponse.Body.Close()
+	if createResponse.StatusCode != 201 {
+		return nil, "", fmt.Errorf("TUS create returned HTTP %d, expected 201", createResponse.StatusCode)
+	}
+	location := createResponse.Header.Get("Location")
+	if location == "" {
+		return nil, "", fmt.Errorf("TUS create did not return a Location header")
+	}
+	uploadURL, err := endpointURL.Parse(location)
+	if err != nil {
+		return nil, "", err
+	}
+	uploadURLText := uploadURL.String()
+
+	patchRequest, err := http.NewRequestWithContext(ctx, "PATCH", uploadURLText, bytes.NewReader(content))
+	if err != nil {
+		return nil, "", err
+	}
+	patchRequest.Header.Set("Tus-Resumable", "1.0.0")
+	patchRequest.Header.Set("Upload-Offset", "0")
+	patchRequest.Header.Set("Content-Type", "application/offset+octet-stream")
+
+	patchResponse, err := client.httpClient.Do(patchRequest)
+	if err != nil {
+		return nil, "", err
+	}
+	defer patchResponse.Body.Close()
+	if patchResponse.StatusCode != 204 {
+		return nil, "", fmt.Errorf("TUS upload returned HTTP %d, expected 204", patchResponse.StatusCode)
+	}
+	remoteOffset, err := strconv.Atoi(patchResponse.Header.Get("Upload-Offset"))
+	if err != nil {
+		return nil, "", err
+	}
+	if remoteOffset != len(content) {
+		return nil, "", fmt.Errorf("TUS upload offset %d, expected %d", remoteOffset, len(content))
+	}
+
+	completedAssembly, err := client.WaitForAssembly(ctx, createdAssembly)
+	if err != nil {
+		return nil, "", err
+	}
+
+	return completedAssembly, uploadURLText, nil
+}
+
+// </api2-generated-feature uploadTusAssembly>
 
 func (assembly *Assembly) makeRequest(ctx context.Context, client *Client) (*http.Request, error) {
 	// TODO: test with huge files

--- a/assembly.go
+++ b/assembly.go
@@ -343,12 +343,12 @@ func (client *Client) UploadTusAssembly(ctx context.Context, fileCount int, cont
 	if uploadResponse.StatusCode != 204 {
 		return nil, "", fmt.Errorf("TUS upload returned HTTP %d, expected 204", uploadResponse.StatusCode)
 	}
-	remoteOffset, err := strconv.Atoi(uploadResponse.Header.Get("Upload-Offset"))
+	uploadOffset, err := strconv.Atoi(uploadResponse.Header.Get("Upload-Offset"))
 	if err != nil {
 		return nil, "", err
 	}
-	if remoteOffset != len(content) {
-		return nil, "", fmt.Errorf("TUS upload offset %d, expected %d", remoteOffset, len(content))
+	if uploadOffset != len(content) {
+		return nil, "", fmt.Errorf("TUS upload offset %d, expected %d", uploadOffset, len(content))
 	}
 
 	completedAssembly, err := client.WaitForAssembly(ctx, createdAssembly)

--- a/assembly.go
+++ b/assembly.go
@@ -86,6 +86,7 @@ type AssemblyInfo struct {
 	ParentID               string                 `json:"parent_id"`
 	AssemblyURL            string                 `json:"assembly_url"`
 	AssemblySSLURL         string                 `json:"assembly_ssl_url"`
+	TUSURL                 string                 `json:"tus_url"`
 	BytesReceived          int                    `json:"bytes_received"`
 	BytesExpected          Integer                `json:"bytes_expected"`
 	StartDate              string                 `json:"start_date"`
@@ -135,9 +136,12 @@ type FileInfo struct {
 	OriginalMd5Hash  string                 `json:"original_md5hash"`
 	OriginalID       string                 `json:"original_id"`
 	OriginalBasename string                 `json:"original_basename"`
+	IsTUSFile        bool                   `json:"is_tus_file"`
+	TUSUploadURL     string                 `json:"tus_upload_url"`
 	URL              string                 `json:"url"`
 	SSLURL           string                 `json:"ssl_url"`
 	Meta             map[string]interface{} `json:"meta"`
+	UserMeta         map[string]interface{} `json:"user_meta"`
 	Cost             int                    `json:"cost"`
 }
 

--- a/assembly.go
+++ b/assembly.go
@@ -519,7 +519,7 @@ func (assembly *Assembly) makeRequest(ctx context.Context, client *Client) (*htt
 // https://api2-amberly.transloadit.com/assemblies/15a6b3701d3811e78d7bfba4db1b053e
 func (client *Client) GetAssembly(ctx context.Context, assemblyURL string) (*AssemblyInfo, error) {
 	var info AssemblyInfo
-	err := client.request(ctx, "GET", assemblyURL, nil, &info)
+	err := client.requestAssemblyURL(ctx, "GET", assemblyURL, &info)
 
 	return &info, err
 }
@@ -539,7 +539,7 @@ func (client *Client) GetAssembly(ctx context.Context, assemblyURL string) (*Ass
 // https://api2-amberly.transloadit.com/assemblies/15a6b3701d3811e78d7bfba4db1b053e
 func (client *Client) CancelAssembly(ctx context.Context, assemblyURL string) (*AssemblyInfo, error) {
 	var info AssemblyInfo
-	err := client.request(ctx, "DELETE", assemblyURL, nil, &info)
+	err := client.requestAssemblyURL(ctx, "DELETE", assemblyURL, &info)
 
 	return &info, err
 }

--- a/assembly.go
+++ b/assembly.go
@@ -289,13 +289,13 @@ func (client *Client) UploadTusAssembly(ctx context.Context, fileCount int, cont
 		return nil, "", err
 	}
 
-	uploadMetadata := make(map[string]string)
+	metadataMap := make(map[string]string)
 	for name, value := range userMeta {
-		uploadMetadata[name] = value
+		metadataMap[name] = value
 	}
-	uploadMetadata["assembly_url"] = createdAssembly.AssemblyURL
-	uploadMetadata["fieldname"] = fieldname
-	uploadMetadata["filename"] = filename
+	metadataMap["assembly_url"] = createdAssembly.AssemblyURL
+	metadataMap["fieldname"] = fieldname
+	metadataMap["filename"] = filename
 
 	createRequest, err := http.NewRequestWithContext(ctx, "POST", endpointURL.String(), nil)
 	if err != nil {
@@ -303,8 +303,8 @@ func (client *Client) UploadTusAssembly(ctx context.Context, fileCount int, cont
 	}
 	createRequest.Header.Set("Tus-Resumable", "1.0.0")
 	createRequest.Header.Set("Upload-Length", strconv.Itoa(len(content)))
-	metadataParts := make([]string, 0, len(uploadMetadata))
-	for name, value := range uploadMetadata {
+	metadataParts := make([]string, 0, len(metadataMap))
+	for name, value := range metadataMap {
 		metadataParts = append(metadataParts, fmt.Sprintf("%s %s", name, base64.StdEncoding.EncodeToString([]byte(value))))
 	}
 	createRequest.Header.Set("Upload-Metadata", strings.Join(metadataParts, ","))
@@ -317,33 +317,33 @@ func (client *Client) UploadTusAssembly(ctx context.Context, fileCount int, cont
 	if createResponse.StatusCode != 201 {
 		return nil, "", fmt.Errorf("TUS create returned HTTP %d, expected 201", createResponse.StatusCode)
 	}
-	location := createResponse.Header.Get("Location")
-	if location == "" {
+	uploadURLLocation := createResponse.Header.Get("Location")
+	if uploadURLLocation == "" {
 		return nil, "", fmt.Errorf("TUS create did not return a Location header")
 	}
-	uploadURL, err := endpointURL.Parse(location)
+	uploadURL, err := endpointURL.Parse(uploadURLLocation)
 	if err != nil {
 		return nil, "", err
 	}
 	uploadURLText := uploadURL.String()
 
-	patchRequest, err := http.NewRequestWithContext(ctx, "PATCH", uploadURLText, bytes.NewReader(content))
+	uploadRequest, err := http.NewRequestWithContext(ctx, "PATCH", uploadURLText, bytes.NewReader(content))
 	if err != nil {
 		return nil, "", err
 	}
-	patchRequest.Header.Set("Tus-Resumable", "1.0.0")
-	patchRequest.Header.Set("Upload-Offset", "0")
-	patchRequest.Header.Set("Content-Type", "application/offset+octet-stream")
+	uploadRequest.Header.Set("Tus-Resumable", "1.0.0")
+	uploadRequest.Header.Set("Upload-Offset", "0")
+	uploadRequest.Header.Set("Content-Type", "application/offset+octet-stream")
 
-	patchResponse, err := client.httpClient.Do(patchRequest)
+	uploadResponse, err := client.httpClient.Do(uploadRequest)
 	if err != nil {
 		return nil, "", err
 	}
-	defer patchResponse.Body.Close()
-	if patchResponse.StatusCode != 204 {
-		return nil, "", fmt.Errorf("TUS upload returned HTTP %d, expected 204", patchResponse.StatusCode)
+	defer uploadResponse.Body.Close()
+	if uploadResponse.StatusCode != 204 {
+		return nil, "", fmt.Errorf("TUS upload returned HTTP %d, expected 204", uploadResponse.StatusCode)
 	}
-	remoteOffset, err := strconv.Atoi(patchResponse.Header.Get("Upload-Offset"))
+	remoteOffset, err := strconv.Atoi(uploadResponse.Header.Get("Upload-Offset"))
 	if err != nil {
 		return nil, "", err
 	}

--- a/assembly.go
+++ b/assembly.go
@@ -233,6 +233,36 @@ func (client *Client) StartAssembly(ctx context.Context, assembly Assembly) (*As
 	return &info, err
 }
 
+// <api2-generated-feature createTusAssembly>
+
+// This block is generated from Transloadit API2 contracts. If it looks wrong,
+// please report the issue instead of editing this block by hand; the source fix
+// belongs in the contract generator so all SDKs stay in sync.
+
+// CreateTusAssembly creates a TUS-ready Assembly that waits for the requested number of resumable uploads before execution continues.
+func (client *Client) CreateTusAssembly(ctx context.Context, fileCount int) (*AssemblyInfo, error) {
+	content := map[string]interface{}{
+		"await": false,
+		"steps": map[string]interface{}{
+			":original": map[string]interface{}{
+				"output_meta": true,
+				"result":      "debug",
+				"robot":       "/upload/handle",
+			},
+		},
+	}
+	formFields := map[string]interface{}{
+		"num_expected_upload_files": fileCount,
+	}
+
+	var assembly AssemblyInfo
+	err := client.requestWithFormFields(ctx, "POST", "assemblies", content, formFields, &assembly)
+
+	return &assembly, err
+}
+
+// </api2-generated-feature createTusAssembly>
+
 func (assembly *Assembly) makeRequest(ctx context.Context, client *Client) (*http.Request, error) {
 	// TODO: test with huge files
 	url := client.config.Endpoint + "/assemblies"

--- a/assembly_test.go
+++ b/assembly_test.go
@@ -2,6 +2,8 @@ package transloadit
 
 import (
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
@@ -89,6 +91,59 @@ func TestGetAssembly(t *testing.T) {
 
 	if assembly.AssemblyURL != assemblyURL {
 		t.Fatal("assembly urls don't match")
+	}
+}
+
+func TestGetAssemblyRejectsUntrustedURLWithoutSendingCredentials(t *testing.T) {
+	requestReceived := make(chan struct{}, 1)
+	untrustedServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		requestReceived <- struct{}{}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"assembly_id":"assembly-id"}`))
+	}))
+	defer untrustedServer.Close()
+
+	configuredServer := httptest.NewServer(http.NotFoundHandler())
+	defer configuredServer.Close()
+
+	config := DefaultConfig
+	config.AuthKey = "key"
+	config.AuthSecret = "secret"
+	config.Endpoint = configuredServer.URL
+	client := NewClient(config)
+
+	_, err := client.GetAssembly(ctx, untrustedServer.URL+"/assemblies/assembly-id")
+	if err == nil {
+		t.Fatal("expected an untrusted Assembly URL error")
+	}
+	select {
+	case <-requestReceived:
+		t.Fatal("sent a request to an untrusted Assembly URL")
+	default:
+	}
+}
+
+func TestGetAssemblyDoesNotAuthenticateNoAuthRequest(t *testing.T) {
+	query := make(chan string, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		query <- request.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"assembly_id":"assembly-id"}`))
+	}))
+	defer server.Close()
+
+	config := DefaultConfig
+	config.AuthKey = "key"
+	config.AuthSecret = "secret"
+	config.Endpoint = server.URL
+	client := NewClient(config)
+
+	_, err := client.GetAssembly(ctx, server.URL+"/assemblies/assembly-id")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rawQuery := <-query; rawQuery != "" {
+		t.Fatalf("expected an unauthenticated request, got query %q", rawQuery)
 	}
 }
 

--- a/assembly_test.go
+++ b/assembly_test.go
@@ -124,6 +124,37 @@ func TestGetAssemblyRejectsUntrustedURLWithoutSendingCredentials(t *testing.T) {
 	}
 }
 
+func TestCancelAssemblyDoesNotFollowRedirects(t *testing.T) {
+	redirectedRequestMethod := make(chan string, 1)
+	redirectedServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		redirectedRequestMethod <- request.Method
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"assembly_id":"assembly-id"}`))
+	}))
+	defer redirectedServer.Close()
+
+	configuredServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		http.Redirect(w, request, redirectedServer.URL+"/assemblies/assembly-id", http.StatusFound)
+	}))
+	defer configuredServer.Close()
+
+	config := DefaultConfig
+	config.AuthKey = "key"
+	config.AuthSecret = "secret"
+	config.Endpoint = configuredServer.URL
+	client := NewClient(config)
+
+	_, err := client.CancelAssembly(ctx, configuredServer.URL+"/assemblies/assembly-id")
+	if err == nil {
+		t.Error("expected a redirect response error")
+	}
+	select {
+	case method := <-redirectedRequestMethod:
+		t.Fatalf("followed an Assembly URL redirect using %s", method)
+	default:
+	}
+}
+
 func TestGetAssemblyDoesNotAuthenticateNoAuthRequest(t *testing.T) {
 	query := make(chan string, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {

--- a/assembly_test.go
+++ b/assembly_test.go
@@ -264,3 +264,50 @@ func TestInteger_MarshalJSON(t *testing.T) {
 		t.Fatal("wrong default value for string")
 	}
 }
+
+func TestAssemblyInfo_TusFields(t *testing.T) {
+	t.Parallel()
+
+	var info AssemblyInfo
+	err := json.Unmarshal([]byte(`{
+		"tus_url": "https://api2.example/resumable/files/",
+		"uploads": [
+			{
+				"is_tus_file": true,
+				"tus_upload_url": "https://api2.example/resumable/files/upload-id",
+				"user_meta": {
+					"hello": "world"
+				}
+			}
+		],
+		"results": {
+			":original": [
+				{
+					"is_tus_file": false,
+					"user_meta": {
+						"hello": "world"
+					}
+				}
+			]
+		}
+	}`), &info)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if info.TUSURL != "https://api2.example/resumable/files/" {
+		t.Fatal("wrong tus url")
+	}
+	if len(info.Uploads) != 1 || !info.Uploads[0].IsTUSFile {
+		t.Fatal("wrong TUS upload marker")
+	}
+	if info.Uploads[0].TUSUploadURL != "https://api2.example/resumable/files/upload-id" {
+		t.Fatal("wrong TUS upload url")
+	}
+	if info.Uploads[0].UserMeta["hello"] != "world" {
+		t.Fatal("wrong upload user meta")
+	}
+	if info.Results[":original"][0].UserMeta["hello"] != "world" {
+		t.Fatal("wrong result user meta")
+	}
+}

--- a/assembly_test.go
+++ b/assembly_test.go
@@ -2,6 +2,7 @@ package transloadit
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -144,6 +145,31 @@ func TestGetAssemblyDoesNotAuthenticateNoAuthRequest(t *testing.T) {
 	}
 	if rawQuery := <-query; rawQuery != "" {
 		t.Fatalf("expected an unauthenticated request, got query %q", rawQuery)
+	}
+}
+
+func TestGetAssemblyAllowsHTTPSForConfiguredHostname(t *testing.T) {
+	requested := false
+	config := DefaultConfig
+	config.AuthKey = "key"
+	config.AuthSecret = "secret"
+	config.Endpoint = "http://api2-devdock.transloadit.dev"
+	client := NewClient(config)
+	client.httpClient.Transport = roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		requested = true
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"assembly_id":"assembly-id"}`)),
+		}, nil
+	})
+
+	_, err := client.GetAssembly(ctx, "https://api2-devdock.transloadit.dev/assemblies/assembly-id")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !requested {
+		t.Fatal("expected an HTTPS request to the configured hostname")
 	}
 }
 

--- a/examples/api2-devdock-assembly-lifecycle/main.go
+++ b/examples/api2-devdock-assembly-lifecycle/main.go
@@ -109,19 +109,28 @@ func main() {
 		fail("get assembly: %v", err)
 	}
 
-	assemblies, err := client.ListAssemblies(ctx, &transloadit.ListOptions{
-		AssemblyID: created.AssemblyID,
-		PageSize:   scenario.List.PageSize,
-	})
-	if err != nil {
-		fail("list assemblies: %v", err)
-	}
-
+	// The Assembly list is eventually consistent: the API acknowledges creation before the
+	// list storage row lands, so poll briefly until the created Assembly shows up.
+	var assemblies transloadit.AssemblyList
 	listContainsCreated := false
-	for _, assembly := range assemblies.Assemblies {
-		if assembly.AssemblyID == created.AssemblyID {
-			listContainsCreated = true
+	for attempt := 0; attempt < 20; attempt++ {
+		assemblies, err = client.ListAssemblies(ctx, &transloadit.ListOptions{
+			AssemblyID: created.AssemblyID,
+			PageSize:   scenario.List.PageSize,
+		})
+		if err != nil {
+			fail("list assemblies: %v", err)
 		}
+
+		for _, assembly := range assemblies.Assemblies {
+			if assembly.AssemblyID == created.AssemblyID {
+				listContainsCreated = true
+			}
+		}
+		if listContainsCreated {
+			break
+		}
+		time.Sleep(500 * time.Millisecond)
 	}
 
 	cancelled, err := client.CancelAssembly(ctx, created.AssemblySSLURL)

--- a/examples/api2-devdock-assembly-lifecycle/main.go
+++ b/examples/api2-devdock-assembly-lifecycle/main.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"time"
+
+	transloadit "github.com/transloadit/go-sdk"
+)
+
+type assemblyLifecycleScenario struct {
+	Assembly struct {
+		FileCount int `json:"fileCount"`
+	} `json:"assembly"`
+	List struct {
+		PageSize int `json:"pageSize"`
+	} `json:"list"`
+	ScenarioID string `json:"scenarioId"`
+}
+
+func requiredEnv(name string) string {
+	value := os.Getenv(name)
+	if value == "" {
+		panic(fmt.Sprintf("%s must be set", name))
+	}
+
+	return value
+}
+
+func fail(format string, args ...interface{}) {
+	panic(fmt.Sprintf(format, args...))
+}
+
+func loadScenario() (assemblyLifecycleScenario, error) {
+	scenarioPath := os.Getenv("API2_SDK_EXAMPLE_SCENARIO")
+	if scenarioPath == "" {
+		scenarioPath = filepath.Join("examples", "api2-devdock-assembly-lifecycle", "api2-scenario.json")
+	}
+
+	contents, err := ioutil.ReadFile(scenarioPath)
+	if err != nil {
+		return assemblyLifecycleScenario{}, err
+	}
+
+	var scenario assemblyLifecycleScenario
+	if err := json.Unmarshal(contents, &scenario); err != nil {
+		return assemblyLifecycleScenario{}, err
+	}
+
+	return scenario, nil
+}
+
+func assemblyResult(info *transloadit.AssemblyInfo) map[string]interface{} {
+	return map[string]interface{}{
+		"assemblyId":     info.AssemblyID,
+		"assemblySslUrl": info.AssemblySSLURL,
+		"assemblyUrl":    info.AssemblyURL,
+		"ok":             info.Ok,
+	}
+}
+
+func writeResult(result map[string]interface{}) error {
+	resultPath := os.Getenv("API2_SDK_EXAMPLE_RESULT")
+	if resultPath == "" {
+		return nil
+	}
+
+	contents, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	return ioutil.WriteFile(resultPath, append(contents, '\n'), 0o644)
+}
+
+func main() {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	scenario, err := loadScenario()
+	if err != nil {
+		fail("load scenario: %v", err)
+	}
+
+	client := transloadit.NewClient(transloadit.Config{
+		AuthKey:    requiredEnv("TRANSLOADIT_KEY"),
+		AuthSecret: requiredEnv("TRANSLOADIT_SECRET"),
+		Endpoint:   requiredEnv("TRANSLOADIT_ENDPOINT"),
+	})
+
+	created, err := client.CreateTusAssembly(ctx, scenario.Assembly.FileCount)
+	if err != nil {
+		fail("create TUS assembly: %v", err)
+	}
+
+	cancelOnExit := true
+	defer func() {
+		if cancelOnExit {
+			_, _ = client.CancelAssembly(context.Background(), created.AssemblySSLURL)
+		}
+	}()
+
+	fetched, err := client.GetAssembly(ctx, created.AssemblySSLURL)
+	if err != nil {
+		fail("get assembly: %v", err)
+	}
+
+	assemblies, err := client.ListAssemblies(ctx, &transloadit.ListOptions{
+		AssemblyID: created.AssemblyID,
+		PageSize:   scenario.List.PageSize,
+	})
+	if err != nil {
+		fail("list assemblies: %v", err)
+	}
+
+	listContainsCreated := false
+	for _, assembly := range assemblies.Assemblies {
+		if assembly.AssemblyID == created.AssemblyID {
+			listContainsCreated = true
+		}
+	}
+
+	cancelled, err := client.CancelAssembly(ctx, created.AssemblySSLURL)
+	if err != nil {
+		fail("cancel assembly: %v", err)
+	}
+	cancelOnExit = false
+
+	if err := writeResult(map[string]interface{}{
+		"cancelled":           assemblyResult(cancelled),
+		"created":             assemblyResult(created),
+		"fetched":             assemblyResult(fetched),
+		"listContainsCreated": listContainsCreated,
+		"listCount":           assemblies.Count,
+	}); err != nil {
+		fail("write result: %v", err)
+	}
+
+	fmt.Printf(
+		"Go Transloadit SDK devdock scenario %s canceled Assembly %s\n",
+		scenario.ScenarioID,
+		created.AssemblyID,
+	)
+}

--- a/examples/api2-devdock-template-lifecycle/main.go
+++ b/examples/api2-devdock-template-lifecycle/main.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -63,7 +64,7 @@ func loadScenario() (templateLifecycleScenario, error) {
 		)
 	}
 
-	contents, err := os.ReadFile(scenarioPath)
+	contents, err := ioutil.ReadFile(scenarioPath)
 	if err != nil {
 		return templateLifecycleScenario{}, err
 	}

--- a/examples/api2-devdock-template-lifecycle/main.go
+++ b/examples/api2-devdock-template-lifecycle/main.go
@@ -1,0 +1,244 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"time"
+
+	transloadit "github.com/transloadit/go-sdk"
+)
+
+type scenarioContent struct {
+	AdditionalProperties map[string]interface{}            `json:"additionalProperties"`
+	Steps                map[string]map[string]interface{} `json:"steps"`
+}
+
+type templateLifecycleScenario struct {
+	Delete struct {
+		ErrorCodeIncludes string `json:"errorCodeIncludes"`
+	} `json:"delete"`
+	List struct {
+		MinimumCount int `json:"minimumCount"`
+		PageSize     int `json:"pageSize"`
+	} `json:"list"`
+	ScenarioID string `json:"scenarioId"`
+	Template   struct {
+		Content              scenarioContent `json:"content"`
+		NamePrefix           string          `json:"namePrefix"`
+		RequireSignatureAuth bool            `json:"requireSignatureAuth"`
+	} `json:"template"`
+	Update struct {
+		Content              scenarioContent `json:"content"`
+		NameSuffix           string          `json:"nameSuffix"`
+		RequireSignatureAuth bool            `json:"requireSignatureAuth"`
+	} `json:"update"`
+}
+
+func requiredEnv(name string) string {
+	value := os.Getenv(name)
+	if value == "" {
+		panic(fmt.Sprintf("%s must be set", name))
+	}
+
+	return value
+}
+
+func fail(format string, args ...interface{}) {
+	panic(fmt.Sprintf(format, args...))
+}
+
+func loadScenario() (templateLifecycleScenario, error) {
+	scenarioPath := os.Getenv("API2_SDK_EXAMPLE_SCENARIO")
+	if scenarioPath == "" {
+		scenarioPath = filepath.Join(
+			"examples",
+			"api2-devdock-template-lifecycle",
+			"api2-scenario.json",
+		)
+	}
+
+	contents, err := os.ReadFile(scenarioPath)
+	if err != nil {
+		return templateLifecycleScenario{}, err
+	}
+
+	var scenario templateLifecycleScenario
+	if err := json.Unmarshal(contents, &scenario); err != nil {
+		return templateLifecycleScenario{}, err
+	}
+
+	return scenario, nil
+}
+
+func applyTemplateContent(template *transloadit.Template, content scenarioContent) {
+	for stepName, step := range content.Steps {
+		template.AddStep(stepName, step)
+	}
+
+	for name, value := range content.AdditionalProperties {
+		template.Content.AdditionalProperties[name] = value
+	}
+}
+
+func newTemplate(name string, requireSignatureAuth bool, content scenarioContent) transloadit.Template {
+	template := transloadit.NewTemplate()
+	template.Name = name
+	template.RequireSignatureAuth = requireSignatureAuth
+	applyTemplateContent(&template, content)
+
+	return template
+}
+
+func assertTemplateContent(label string, template transloadit.Template, expected scenarioContent) {
+	for stepName, expectedStep := range expected.Steps {
+		actualStep, ok := template.Content.Steps[stepName]
+		if !ok {
+			fail("%s response did not include step %q", label, stepName)
+		}
+		if !reflect.DeepEqual(actualStep, expectedStep) {
+			fail("%s response step %q was %v, expected %v", label, stepName, actualStep, expectedStep)
+		}
+	}
+
+	for name, expectedValue := range expected.AdditionalProperties {
+		actualValue, ok := template.Content.AdditionalProperties[name]
+		if !ok {
+			fail("%s response did not include content property %q", label, name)
+		}
+		if !reflect.DeepEqual(actualValue, expectedValue) {
+			fail(
+				"%s response content property %q was %v, expected %v",
+				label,
+				name,
+				actualValue,
+				expectedValue,
+			)
+		}
+	}
+}
+
+func main() {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	scenario, err := loadScenario()
+	if err != nil {
+		fail("load scenario: %v", err)
+	}
+
+	client := transloadit.NewClient(transloadit.Config{
+		AuthKey:    requiredEnv("TRANSLOADIT_KEY"),
+		AuthSecret: requiredEnv("TRANSLOADIT_SECRET"),
+		Endpoint:   requiredEnv("TRANSLOADIT_ENDPOINT"),
+	})
+
+	templateName := fmt.Sprintf("%s-%d", scenario.Template.NamePrefix, time.Now().UnixNano())
+	template := newTemplate(
+		templateName,
+		scenario.Template.RequireSignatureAuth,
+		scenario.Template.Content,
+	)
+
+	templateID, err := client.CreateTemplate(ctx, template)
+	if err != nil {
+		fail("create template: %v", err)
+	}
+	if templateID == "" {
+		fail("create template returned an empty id")
+	}
+
+	deleteTemplate := true
+	defer func() {
+		if deleteTemplate {
+			_ = client.DeleteTemplate(context.Background(), templateID)
+		}
+	}()
+
+	fetched, err := client.GetTemplate(ctx, templateID)
+	if err != nil {
+		fail("get template: %v", err)
+	}
+	if fetched.ID != templateID {
+		fail("get template returned id %q, expected %q", fetched.ID, templateID)
+	}
+	if fetched.Name != templateName {
+		fail("get template returned name %q, expected %q", fetched.Name, templateName)
+	}
+	if fetched.RequireSignatureAuth != scenario.Template.RequireSignatureAuth {
+		fail(
+			"get template returned RequireSignatureAuth=%v, expected %v",
+			fetched.RequireSignatureAuth,
+			scenario.Template.RequireSignatureAuth,
+		)
+	}
+	assertTemplateContent("get template", fetched, scenario.Template.Content)
+
+	templateList, err := client.ListTemplates(ctx, &transloadit.ListOptions{
+		PageSize: scenario.List.PageSize,
+	})
+	if err != nil {
+		fail("list templates: %v", err)
+	}
+	if templateList.Count < scenario.List.MinimumCount {
+		fail(
+			"list templates returned count=%d, expected at least %d",
+			templateList.Count,
+			scenario.List.MinimumCount,
+		)
+	}
+
+	updatedTemplate := newTemplate(
+		templateName+scenario.Update.NameSuffix,
+		scenario.Update.RequireSignatureAuth,
+		scenario.Update.Content,
+	)
+
+	if err := client.UpdateTemplate(ctx, templateID, updatedTemplate); err != nil {
+		fail("update template: %v", err)
+	}
+
+	fetchedUpdated, err := client.GetTemplate(ctx, templateID)
+	if err != nil {
+		fail("get updated template: %v", err)
+	}
+	if fetchedUpdated.Name != updatedTemplate.Name {
+		fail("updated template returned name %q, expected %q", fetchedUpdated.Name, updatedTemplate.Name)
+	}
+	if fetchedUpdated.RequireSignatureAuth != scenario.Update.RequireSignatureAuth {
+		fail(
+			"updated template returned RequireSignatureAuth=%v, expected %v",
+			fetchedUpdated.RequireSignatureAuth,
+			scenario.Update.RequireSignatureAuth,
+		)
+	}
+	assertTemplateContent("updated template", fetchedUpdated, scenario.Update.Content)
+
+	if err := client.DeleteTemplate(ctx, templateID); err != nil {
+		fail("delete template: %v", err)
+	}
+	deleteTemplate = false
+
+	_, err = client.GetTemplate(ctx, templateID)
+	if err == nil {
+		fail("get deleted template succeeded unexpectedly")
+	}
+	var requestErr transloadit.RequestError
+	if !errors.As(err, &requestErr) {
+		fail("get deleted template returned %T, expected transloadit.RequestError", err)
+	}
+	if !strings.Contains(requestErr.Code, scenario.Delete.ErrorCodeIncludes) {
+		fail("get deleted template returned unexpected error code %q", requestErr.Code)
+	}
+
+	fmt.Printf(
+		"Go Transloadit SDK devdock scenario %s passed for %s\n",
+		scenario.ScenarioID,
+		requiredEnv("TRANSLOADIT_ENDPOINT"),
+	)
+}

--- a/examples/api2-devdock-template-lifecycle/main.go
+++ b/examples/api2-devdock-template-lifecycle/main.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -61,7 +62,7 @@ func loadScenario() (templateLifecycleScenario, error) {
 		)
 	}
 
-	contents, err := os.ReadFile(scenarioPath)
+	contents, err := ioutil.ReadFile(scenarioPath)
 	if err != nil {
 		return templateLifecycleScenario{}, err
 	}
@@ -221,5 +222,5 @@ func writeResult(result map[string]interface{}) error {
 		return err
 	}
 
-	return os.WriteFile(resultPath, append(contents, '\n'), 0o644)
+	return ioutil.WriteFile(resultPath, append(contents, '\n'), 0o644)
 }

--- a/examples/api2-devdock-template-lifecycle/main.go
+++ b/examples/api2-devdock-template-lifecycle/main.go
@@ -5,11 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
-	"reflect"
-	"strings"
 	"time"
 
 	transloadit "github.com/transloadit/go-sdk"
@@ -64,7 +61,7 @@ func loadScenario() (templateLifecycleScenario, error) {
 		)
 	}
 
-	contents, err := ioutil.ReadFile(scenarioPath)
+	contents, err := os.ReadFile(scenarioPath)
 	if err != nil {
 		return templateLifecycleScenario{}, err
 	}
@@ -94,34 +91,6 @@ func newTemplate(name string, requireSignatureAuth bool, content scenarioContent
 	applyTemplateContent(&template, content)
 
 	return template
-}
-
-func assertTemplateContent(label string, template transloadit.Template, expected scenarioContent) {
-	for stepName, expectedStep := range expected.Steps {
-		actualStep, ok := template.Content.Steps[stepName]
-		if !ok {
-			fail("%s response did not include step %q", label, stepName)
-		}
-		if !reflect.DeepEqual(actualStep, expectedStep) {
-			fail("%s response step %q was %v, expected %v", label, stepName, actualStep, expectedStep)
-		}
-	}
-
-	for name, expectedValue := range expected.AdditionalProperties {
-		actualValue, ok := template.Content.AdditionalProperties[name]
-		if !ok {
-			fail("%s response did not include content property %q", label, name)
-		}
-		if !reflect.DeepEqual(actualValue, expectedValue) {
-			fail(
-				"%s response content property %q was %v, expected %v",
-				label,
-				name,
-				actualValue,
-				expectedValue,
-			)
-		}
-	}
 }
 
 func main() {
@@ -165,33 +134,12 @@ func main() {
 	if err != nil {
 		fail("get template: %v", err)
 	}
-	if fetched.ID != templateID {
-		fail("get template returned id %q, expected %q", fetched.ID, templateID)
-	}
-	if fetched.Name != templateName {
-		fail("get template returned name %q, expected %q", fetched.Name, templateName)
-	}
-	if fetched.RequireSignatureAuth != scenario.Template.RequireSignatureAuth {
-		fail(
-			"get template returned RequireSignatureAuth=%v, expected %v",
-			fetched.RequireSignatureAuth,
-			scenario.Template.RequireSignatureAuth,
-		)
-	}
-	assertTemplateContent("get template", fetched, scenario.Template.Content)
 
 	templateList, err := client.ListTemplates(ctx, &transloadit.ListOptions{
 		PageSize: scenario.List.PageSize,
 	})
 	if err != nil {
 		fail("list templates: %v", err)
-	}
-	if templateList.Count < scenario.List.MinimumCount {
-		fail(
-			"list templates returned count=%d, expected at least %d",
-			templateList.Count,
-			scenario.List.MinimumCount,
-		)
 	}
 
 	updatedTemplate := newTemplate(
@@ -208,17 +156,6 @@ func main() {
 	if err != nil {
 		fail("get updated template: %v", err)
 	}
-	if fetchedUpdated.Name != updatedTemplate.Name {
-		fail("updated template returned name %q, expected %q", fetchedUpdated.Name, updatedTemplate.Name)
-	}
-	if fetchedUpdated.RequireSignatureAuth != scenario.Update.RequireSignatureAuth {
-		fail(
-			"updated template returned RequireSignatureAuth=%v, expected %v",
-			fetchedUpdated.RequireSignatureAuth,
-			scenario.Update.RequireSignatureAuth,
-		)
-	}
-	assertTemplateContent("updated template", fetchedUpdated, scenario.Update.Content)
 
 	if err := client.DeleteTemplate(ctx, templateID); err != nil {
 		fail("delete template: %v", err)
@@ -226,15 +163,28 @@ func main() {
 	deleteTemplate = false
 
 	_, err = client.GetTemplate(ctx, templateID)
-	if err == nil {
-		fail("get deleted template succeeded unexpectedly")
-	}
+	deletedGetSucceeded := err == nil
+	deletedErrorCode := ""
 	var requestErr transloadit.RequestError
-	if !errors.As(err, &requestErr) {
+	if err != nil && !errors.As(err, &requestErr) {
 		fail("get deleted template returned %T, expected transloadit.RequestError", err)
 	}
-	if !strings.Contains(requestErr.Code, scenario.Delete.ErrorCodeIncludes) {
-		fail("get deleted template returned unexpected error code %q", requestErr.Code)
+	if err != nil {
+		deletedErrorCode = requestErr.Code
+	}
+
+	result := map[string]interface{}{
+		"deletedErrorCode":    deletedErrorCode,
+		"deletedGetSucceeded": deletedGetSucceeded,
+		"fetched":             templateResult(fetched),
+		"listCount":           templateList.Count,
+		"templateId":          templateID,
+		"templateName":        templateName,
+		"updated":             templateResult(fetchedUpdated),
+		"updatedTemplateName": updatedTemplate.Name,
+	}
+	if err := writeResult(result); err != nil {
+		fail("write result: %v", err)
 	}
 
 	fmt.Printf(
@@ -242,4 +192,34 @@ func main() {
 		scenario.ScenarioID,
 		requiredEnv("TRANSLOADIT_ENDPOINT"),
 	)
+}
+
+func templateResult(template transloadit.Template) map[string]interface{} {
+	content := map[string]interface{}{
+		"steps": template.Content.Steps,
+	}
+	for name, value := range template.Content.AdditionalProperties {
+		content[name] = value
+	}
+
+	return map[string]interface{}{
+		"content":              content,
+		"id":                   template.ID,
+		"name":                 template.Name,
+		"requireSignatureAuth": template.RequireSignatureAuth,
+	}
+}
+
+func writeResult(result map[string]interface{}) error {
+	resultPath := os.Getenv("API2_SDK_EXAMPLE_RESULT")
+	if resultPath == "" {
+		return nil
+	}
+
+	contents, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(resultPath, append(contents, '\n'), 0o644)
 }

--- a/examples/api2-devdock-tus-assembly/main.go
+++ b/examples/api2-devdock-tus-assembly/main.go
@@ -1,0 +1,508 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	transloadit "github.com/transloadit/go-sdk"
+)
+
+func requiredEnv(name string) string {
+	value := os.Getenv(name)
+	if value == "" {
+		panic(fmt.Sprintf("%s must be set", name))
+	}
+
+	return value
+}
+
+func fail(format string, args ...interface{}) {
+	panic(fmt.Sprintf(format, args...))
+}
+
+func loadScenario() (map[string]interface{}, error) {
+	scenarioPath := os.Getenv("API2_SDK_EXAMPLE_SCENARIO")
+	if scenarioPath == "" {
+		scenarioPath = filepath.Join("examples", "api2-devdock-tus-assembly", "api2-scenario.json")
+	}
+
+	contents, err := os.ReadFile(scenarioPath)
+	if err != nil {
+		return nil, err
+	}
+
+	var scenario map[string]interface{}
+	if err := json.Unmarshal(contents, &scenario); err != nil {
+		return nil, err
+	}
+
+	return scenario, nil
+}
+
+func objectValue(value interface{}, label string) (map[string]interface{}, error) {
+	object, ok := value.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("%s must be an object", label)
+	}
+
+	return object, nil
+}
+
+func arrayValue(value interface{}, label string) ([]interface{}, error) {
+	array, ok := value.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("%s must be an array", label)
+	}
+
+	return array, nil
+}
+
+func stringValue(value interface{}, label string) (string, error) {
+	text, ok := value.(string)
+	if !ok {
+		return "", fmt.Errorf("%s must be a string", label)
+	}
+
+	return text, nil
+}
+
+func intValue(value interface{}, label string) (int, error) {
+	switch number := value.(type) {
+	case float64:
+		if float64(int(number)) != number {
+			return 0, fmt.Errorf("%s must be an integer", label)
+		}
+
+		return int(number), nil
+	case int:
+		return number, nil
+	case string:
+		parsed, err := strconv.Atoi(number)
+		if err != nil {
+			return 0, fmt.Errorf("%s must be an integer", label)
+		}
+
+		return parsed, nil
+	default:
+		return 0, fmt.Errorf("%s must be an integer", label)
+	}
+}
+
+func scalarString(value interface{}) string {
+	switch typed := value.(type) {
+	case bool:
+		return strconv.FormatBool(typed)
+	case float64:
+		return strconv.FormatFloat(typed, 'f', -1, 64)
+	case int:
+		return strconv.Itoa(typed)
+	case string:
+		return typed
+	default:
+		serialized, err := json.Marshal(typed)
+		if err != nil {
+			return fmt.Sprintf("%v", typed)
+		}
+
+		return string(serialized)
+	}
+}
+
+func readPath(value interface{}, pathParts []interface{}, label string) (interface{}, error) {
+	current := value
+	for _, part := range pathParts {
+		if object, ok := current.(map[string]interface{}); ok {
+			key, ok := part.(string)
+			if !ok {
+				return nil, fmt.Errorf("%s path cannot read non-string key %v from object", label, part)
+			}
+			next, ok := object[key]
+			if !ok {
+				return nil, fmt.Errorf("%s path is missing key %q", label, key)
+			}
+			current = next
+			continue
+		}
+
+		if array, ok := current.([]interface{}); ok {
+			index, err := intValue(part, label)
+			if err != nil {
+				return nil, err
+			}
+			if index < 0 || index >= len(array) {
+				return nil, fmt.Errorf("%s path index %d is out of range", label, index)
+			}
+			current = array[index]
+			continue
+		}
+
+		return nil, fmt.Errorf("%s path cannot read %v from %v", label, part, current)
+	}
+
+	return current, nil
+}
+
+func resolveValue(
+	valueSpec interface{},
+	context map[string]interface{},
+	label string,
+) (interface{}, error) {
+	spec, err := objectValue(valueSpec, label)
+	if err != nil {
+		return nil, err
+	}
+	if literal, ok := spec["value"]; ok {
+		return literal, nil
+	}
+
+	source, err := objectValue(spec["source"], label+".source")
+	if err != nil {
+		return nil, err
+	}
+	root, err := stringValue(source["root"], label+".source.root")
+	if err != nil {
+		return nil, err
+	}
+	rootValue, ok := context[root]
+	if !ok {
+		return nil, fmt.Errorf("%s source root %q is unavailable", label, root)
+	}
+	pathParts, err := arrayValue(source["path"], label+".source.path")
+	if err != nil {
+		return nil, err
+	}
+
+	return readPath(rootValue, pathParts, label)
+}
+
+func asJsonObject(value interface{}, label string) (map[string]interface{}, error) {
+	contents, err := json.Marshal(value)
+	if err != nil {
+		return nil, err
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(contents, &result); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func createAssembly(
+	ctx context.Context,
+	client transloadit.Client,
+	scenario map[string]interface{},
+) (*transloadit.AssemblyInfo, map[string]interface{}, error) {
+	createConfig, err := objectValue(scenario["createTusAssembly"], "createTusAssembly")
+	if err != nil {
+		return nil, nil, err
+	}
+	input, err := objectValue(createConfig["input"], "createTusAssembly.input")
+	if err != nil {
+		return nil, nil, err
+	}
+	fileCount, err := intValue(input["file_count"], "createTusAssembly.input.file_count")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	info, err := client.CreateTusAssembly(ctx, fileCount)
+	if err != nil {
+		return nil, nil, err
+	}
+	createResponse, err := asJsonObject(info, "create response")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	requiredPaths, err := arrayValue(
+		createConfig["requiredResponsePaths"],
+		"createTusAssembly.requiredResponsePaths",
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+	for index, rawPath := range requiredPaths {
+		pathParts, err := arrayValue(
+			rawPath,
+			fmt.Sprintf("createTusAssembly.requiredResponsePaths[%d]", index),
+		)
+		if err != nil {
+			return nil, nil, err
+		}
+		value, err := readPath(
+			createResponse,
+			pathParts,
+			fmt.Sprintf("createTusAssembly.requiredResponsePaths[%d]", index),
+		)
+		if err != nil {
+			return nil, nil, err
+		}
+		if scalarString(value) == "" {
+			return nil, nil, fmt.Errorf("create response path %v is empty", pathParts)
+		}
+	}
+
+	return info, createResponse, nil
+}
+
+func scenarioBytes(scenario map[string]interface{}) ([]byte, error) {
+	upload, err := objectValue(scenario["upload"], "upload")
+	if err != nil {
+		return nil, err
+	}
+	source, err := objectValue(upload["source"], "upload.source")
+	if err != nil {
+		return nil, err
+	}
+	kind, err := stringValue(source["kind"], "upload.source.kind")
+	if err != nil {
+		return nil, err
+	}
+	if kind != "bytes" {
+		return nil, fmt.Errorf("unsupported scenario source kind %q", kind)
+	}
+	encoding, err := stringValue(source["encoding"], "upload.source.encoding")
+	if err != nil {
+		return nil, err
+	}
+	if encoding != "utf8" {
+		return nil, fmt.Errorf("unsupported scenario source encoding %q", encoding)
+	}
+	value, err := stringValue(source["value"], "upload.source.value")
+	if err != nil {
+		return nil, err
+	}
+
+	return []byte(value), nil
+}
+
+func uploadMetadata(
+	scenario map[string]interface{},
+	createResponse map[string]interface{},
+) (map[string]string, error) {
+	upload, err := objectValue(scenario["upload"], "upload")
+	if err != nil {
+		return nil, err
+	}
+	fields, err := arrayValue(upload["metadata"], "upload.metadata")
+	if err != nil {
+		return nil, err
+	}
+
+	context := map[string]interface{}{
+		"createResponse": createResponse,
+		"scenario":       scenario,
+	}
+	metadata := map[string]string{}
+	for index, rawField := range fields {
+		label := fmt.Sprintf("upload.metadata[%d]", index)
+		field, err := objectValue(rawField, label)
+		if err != nil {
+			return nil, err
+		}
+		name, err := stringValue(field["name"], label+".name")
+		if err != nil {
+			return nil, err
+		}
+		value, err := resolveValue(field["value"], context, label+".value")
+		if err != nil {
+			return nil, err
+		}
+		metadata[name] = scalarString(value)
+	}
+
+	return metadata, nil
+}
+
+func tusMetadataHeader(metadata map[string]string) string {
+	parts := make([]string, 0, len(metadata))
+	for name, value := range metadata {
+		encoded := base64.StdEncoding.EncodeToString([]byte(value))
+		parts = append(parts, fmt.Sprintf("%s %s", name, encoded))
+	}
+
+	return strings.Join(parts, ",")
+}
+
+func checkedResponse(response *http.Response, expectedStatus int, label string) error {
+	defer response.Body.Close()
+	if response.StatusCode == expectedStatus {
+		return nil
+	}
+
+	body, _ := io.ReadAll(response.Body)
+	return fmt.Errorf("%s returned HTTP %d: %s", label, response.StatusCode, string(body))
+}
+
+func uploadWithTus(
+	ctx context.Context,
+	scenario map[string]interface{},
+	createResponse map[string]interface{},
+) (string, error) {
+	uploadConfig, err := objectValue(scenario["upload"], "upload")
+	if err != nil {
+		return "", err
+	}
+	context := map[string]interface{}{
+		"createResponse": createResponse,
+		"scenario":       scenario,
+	}
+	endpointValue, err := resolveValue(uploadConfig["tusUrl"], context, "upload.tusUrl")
+	if err != nil {
+		return "", err
+	}
+	endpointURL, err := url.Parse(scalarString(endpointValue))
+	if err != nil {
+		return "", err
+	}
+	content, err := scenarioBytes(scenario)
+	if err != nil {
+		return "", err
+	}
+	chunkSize, err := stringValue(uploadConfig["chunkSize"], "upload.chunkSize")
+	if err != nil {
+		return "", err
+	}
+	if chunkSize != "full-file" {
+		return "", fmt.Errorf("unsupported chunk size policy %q", chunkSize)
+	}
+	metadata, err := uploadMetadata(scenario, createResponse)
+	if err != nil {
+		return "", err
+	}
+
+	createRequest, err := http.NewRequestWithContext(ctx, http.MethodPost, endpointURL.String(), nil)
+	if err != nil {
+		return "", err
+	}
+	createRequest.Header.Set("Tus-Resumable", "1.0.0")
+	createRequest.Header.Set("Upload-Length", strconv.Itoa(len(content)))
+	createRequest.Header.Set("Upload-Metadata", tusMetadataHeader(metadata))
+
+	createResponseHttp, err := http.DefaultClient.Do(createRequest)
+	if err != nil {
+		return "", err
+	}
+	if err := checkedResponse(createResponseHttp, http.StatusCreated, "TUS create"); err != nil {
+		return "", err
+	}
+	location := createResponseHttp.Header.Get("Location")
+	if location == "" {
+		return "", fmt.Errorf("TUS create did not return a Location header")
+	}
+	uploadURL, err := endpointURL.Parse(location)
+	if err != nil {
+		return "", err
+	}
+
+	patchRequest, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPatch,
+		uploadURL.String(),
+		bytes.NewReader(content),
+	)
+	if err != nil {
+		return "", err
+	}
+	patchRequest.Header.Set("Tus-Resumable", "1.0.0")
+	patchRequest.Header.Set("Upload-Offset", "0")
+	patchRequest.Header.Set("Content-Type", "application/offset+octet-stream")
+
+	patchResponse, err := http.DefaultClient.Do(patchRequest)
+	if err != nil {
+		return "", err
+	}
+	if err := checkedResponse(patchResponse, http.StatusNoContent, "TUS upload"); err != nil {
+		return "", err
+	}
+	remoteOffset, err := intValue(patchResponse.Header.Get("Upload-Offset"), "Upload-Offset")
+	if err != nil {
+		return "", err
+	}
+	if remoteOffset != len(content) {
+		return "", fmt.Errorf("TUS upload offset %d, expected %d", remoteOffset, len(content))
+	}
+
+	return uploadURL.String(), nil
+}
+
+func writeResult(
+	createResponse map[string]interface{},
+	status map[string]interface{},
+	uploadURL string,
+) error {
+	resultPath := os.Getenv("API2_SDK_EXAMPLE_RESULT")
+	if resultPath == "" {
+		return nil
+	}
+
+	contents, err := json.MarshalIndent(
+		map[string]interface{}{
+			"createResponse": createResponse,
+			"status":         status,
+			"uploadUrl":      uploadURL,
+		},
+		"",
+		"  ",
+	)
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(resultPath, append(contents, '\n'), 0o644)
+}
+
+func main() {
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	scenario, err := loadScenario()
+	if err != nil {
+		fail("load scenario: %v", err)
+	}
+
+	client := transloadit.NewClient(transloadit.Config{
+		AuthKey:    requiredEnv("TRANSLOADIT_KEY"),
+		AuthSecret: requiredEnv("TRANSLOADIT_SECRET"),
+		Endpoint:   requiredEnv("TRANSLOADIT_ENDPOINT"),
+	})
+
+	info, createResponse, err := createAssembly(ctx, client, scenario)
+	if err != nil {
+		fail("create TUS assembly: %v", err)
+	}
+	uploadURL, err := uploadWithTus(ctx, scenario, createResponse)
+	if err != nil {
+		fail("upload: %v", err)
+	}
+	statusInfo, err := client.WaitForAssembly(ctx, info)
+	if err != nil {
+		fail("wait for assembly: %v", err)
+	}
+	status, err := asJsonObject(statusInfo, "assembly status")
+	if err != nil {
+		fail("serialize assembly status: %v", err)
+	}
+	if err := writeResult(createResponse, status, uploadURL); err != nil {
+		fail("write result: %v", err)
+	}
+
+	scenarioID, err := stringValue(scenario["scenarioId"], "scenarioId")
+	if err != nil {
+		fail("read scenario id: %v", err)
+	}
+	fmt.Printf("Go Transloadit SDK devdock scenario %s uploaded to %s\n", scenarioID, uploadURL)
+}

--- a/examples/api2-devdock-tus-assembly/main.go
+++ b/examples/api2-devdock-tus-assembly/main.go
@@ -127,7 +127,6 @@ func main() {
 
 	statusInfo, uploadURL, err := client.UploadTusAssembly(
 		ctx,
-		input.FileCount,
 		[]byte(input.Upload.Content),
 		input.Upload.Field,
 		input.Upload.Filename,

--- a/examples/api2-devdock-tus-assembly/main.go
+++ b/examples/api2-devdock-tus-assembly/main.go
@@ -186,6 +186,42 @@ func resolveValue(
 	return readPath(rootValue, pathParts, label)
 }
 
+func featurePreparation(
+	scenario map[string]interface{},
+	featureID string,
+) (map[string]interface{}, string, error) {
+	preparations, err := arrayValue(scenario["preparations"], "preparations")
+	if err != nil {
+		return nil, "", err
+	}
+
+	for index, rawPreparation := range preparations {
+		label := fmt.Sprintf("preparations[%d]", index)
+		preparation, err := objectValue(rawPreparation, label)
+		if err != nil {
+			return nil, "", err
+		}
+		currentFeatureID, err := stringValue(preparation["featureId"], label+".featureId")
+		if err != nil {
+			return nil, "", err
+		}
+		if currentFeatureID != featureID {
+			continue
+		}
+		kind, err := stringValue(preparation["kind"], label+".kind")
+		if err != nil {
+			return nil, "", err
+		}
+		if kind != "feature-call" {
+			return nil, "", fmt.Errorf("%s must be a feature-call preparation", label)
+		}
+
+		return preparation, label, nil
+	}
+
+	return nil, "", fmt.Errorf("scenario has no preparation for feature %q", featureID)
+}
+
 func asJsonObject(value interface{}, label string) (map[string]interface{}, error) {
 	contents, err := json.Marshal(value)
 	if err != nil {
@@ -205,15 +241,15 @@ func createAssembly(
 	client transloadit.Client,
 	scenario map[string]interface{},
 ) (*transloadit.AssemblyInfo, map[string]interface{}, error) {
-	createConfig, err := objectValue(scenario["createTusAssembly"], "createTusAssembly")
+	createConfig, createConfigLabel, err := featurePreparation(scenario, "createTusAssembly")
 	if err != nil {
 		return nil, nil, err
 	}
-	input, err := objectValue(createConfig["input"], "createTusAssembly.input")
+	input, err := objectValue(createConfig["input"], createConfigLabel+".input")
 	if err != nil {
 		return nil, nil, err
 	}
-	fileCount, err := intValue(input["file_count"], "createTusAssembly.input.file_count")
+	fileCount, err := intValue(input["file_count"], createConfigLabel+".input.file_count")
 	if err != nil {
 		return nil, nil, err
 	}
@@ -229,7 +265,7 @@ func createAssembly(
 
 	requiredPaths, err := arrayValue(
 		createConfig["requiredResponsePaths"],
-		"createTusAssembly.requiredResponsePaths",
+		createConfigLabel+".requiredResponsePaths",
 	)
 	if err != nil {
 		return nil, nil, err
@@ -237,7 +273,7 @@ func createAssembly(
 	for index, rawPath := range requiredPaths {
 		pathParts, err := arrayValue(
 			rawPath,
-			fmt.Sprintf("createTusAssembly.requiredResponsePaths[%d]", index),
+			fmt.Sprintf("%s.requiredResponsePaths[%d]", createConfigLabel, index),
 		)
 		if err != nil {
 			return nil, nil, err
@@ -245,7 +281,7 @@ func createAssembly(
 		value, err := readPath(
 			createResponse,
 			pathParts,
-			fmt.Sprintf("createTusAssembly.requiredResponsePaths[%d]", index),
+			fmt.Sprintf("%s.requiredResponsePaths[%d]", createConfigLabel, index),
 		)
 		if err != nil {
 			return nil, nil, err

--- a/examples/api2-devdock-tus-assembly/main.go
+++ b/examples/api2-devdock-tus-assembly/main.go
@@ -6,7 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -37,7 +37,7 @@ func loadScenario() (map[string]interface{}, error) {
 		scenarioPath = filepath.Join("examples", "api2-devdock-tus-assembly", "api2-scenario.json")
 	}
 
-	contents, err := os.ReadFile(scenarioPath)
+	contents, err := ioutil.ReadFile(scenarioPath)
 	if err != nil {
 		return nil, err
 	}
@@ -343,7 +343,7 @@ func checkedResponse(response *http.Response, expectedStatus int, label string) 
 		return nil
 	}
 
-	body, _ := io.ReadAll(response.Body)
+	body, _ := ioutil.ReadAll(response.Body)
 	return fmt.Errorf("%s returned HTTP %d: %s", label, response.StatusCode, string(body))
 }
 
@@ -462,7 +462,7 @@ func writeResult(
 		return err
 	}
 
-	return os.WriteFile(resultPath, append(contents, '\n'), 0o644)
+	return ioutil.WriteFile(resultPath, append(contents, '\n'), 0o644)
 }
 
 func main() {

--- a/examples/api2-devdock-tus-assembly/main.go
+++ b/examples/api2-devdock-tus-assembly/main.go
@@ -1,18 +1,13 @@
 package main
 
 import (
-	"bytes"
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"net/http"
-	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
-	"strings"
 	"time"
 
 	transloadit "github.com/transloadit/go-sdk"
@@ -99,93 +94,6 @@ func intValue(value interface{}, label string) (int, error) {
 	}
 }
 
-func scalarString(value interface{}) string {
-	switch typed := value.(type) {
-	case bool:
-		return strconv.FormatBool(typed)
-	case float64:
-		return strconv.FormatFloat(typed, 'f', -1, 64)
-	case int:
-		return strconv.Itoa(typed)
-	case string:
-		return typed
-	default:
-		serialized, err := json.Marshal(typed)
-		if err != nil {
-			return fmt.Sprintf("%v", typed)
-		}
-
-		return string(serialized)
-	}
-}
-
-func readPath(value interface{}, pathParts []interface{}, label string) (interface{}, error) {
-	current := value
-	for _, part := range pathParts {
-		if object, ok := current.(map[string]interface{}); ok {
-			key, ok := part.(string)
-			if !ok {
-				return nil, fmt.Errorf("%s path cannot read non-string key %v from object", label, part)
-			}
-			next, ok := object[key]
-			if !ok {
-				return nil, fmt.Errorf("%s path is missing key %q", label, key)
-			}
-			current = next
-			continue
-		}
-
-		if array, ok := current.([]interface{}); ok {
-			index, err := intValue(part, label)
-			if err != nil {
-				return nil, err
-			}
-			if index < 0 || index >= len(array) {
-				return nil, fmt.Errorf("%s path index %d is out of range", label, index)
-			}
-			current = array[index]
-			continue
-		}
-
-		return nil, fmt.Errorf("%s path cannot read %v from %v", label, part, current)
-	}
-
-	return current, nil
-}
-
-func resolveValue(
-	valueSpec interface{},
-	context map[string]interface{},
-	label string,
-) (interface{}, error) {
-	spec, err := objectValue(valueSpec, label)
-	if err != nil {
-		return nil, err
-	}
-	if literal, ok := spec["value"]; ok {
-		return literal, nil
-	}
-
-	source, err := objectValue(spec["source"], label+".source")
-	if err != nil {
-		return nil, err
-	}
-	root, err := stringValue(source["root"], label+".source.root")
-	if err != nil {
-		return nil, err
-	}
-	rootValue, ok := context[root]
-	if !ok {
-		return nil, fmt.Errorf("%s source root %q is unavailable", label, root)
-	}
-	pathParts, err := arrayValue(source["path"], label+".source.path")
-	if err != nil {
-		return nil, err
-	}
-
-	return readPath(rootValue, pathParts, label)
-}
-
 func featurePreparation(
 	scenario map[string]interface{},
 	featureID string,
@@ -236,62 +144,17 @@ func asJsonObject(value interface{}, label string) (map[string]interface{}, erro
 	return result, nil
 }
 
-func createAssembly(
-	ctx context.Context,
-	client transloadit.Client,
-	scenario map[string]interface{},
-) (*transloadit.AssemblyInfo, map[string]interface{}, error) {
+func scenarioFileCount(scenario map[string]interface{}) (int, error) {
 	createConfig, createConfigLabel, err := featurePreparation(scenario, "createTusAssembly")
 	if err != nil {
-		return nil, nil, err
+		return 0, err
 	}
 	input, err := objectValue(createConfig["input"], createConfigLabel+".input")
 	if err != nil {
-		return nil, nil, err
-	}
-	fileCount, err := intValue(input["file_count"], createConfigLabel+".input.file_count")
-	if err != nil {
-		return nil, nil, err
+		return 0, err
 	}
 
-	info, err := client.CreateTusAssembly(ctx, fileCount)
-	if err != nil {
-		return nil, nil, err
-	}
-	createResponse, err := asJsonObject(info, "create response")
-	if err != nil {
-		return nil, nil, err
-	}
-
-	requiredPaths, err := arrayValue(
-		createConfig["requiredResponsePaths"],
-		createConfigLabel+".requiredResponsePaths",
-	)
-	if err != nil {
-		return nil, nil, err
-	}
-	for index, rawPath := range requiredPaths {
-		pathParts, err := arrayValue(
-			rawPath,
-			fmt.Sprintf("%s.requiredResponsePaths[%d]", createConfigLabel, index),
-		)
-		if err != nil {
-			return nil, nil, err
-		}
-		value, err := readPath(
-			createResponse,
-			pathParts,
-			fmt.Sprintf("%s.requiredResponsePaths[%d]", createConfigLabel, index),
-		)
-		if err != nil {
-			return nil, nil, err
-		}
-		if scalarString(value) == "" {
-			return nil, nil, fmt.Errorf("create response path %v is empty", pathParts)
-		}
-	}
-
-	return info, createResponse, nil
+	return intValue(input["file_count"], createConfigLabel+".input.file_count")
 }
 
 func scenarioBytes(scenario map[string]interface{}) ([]byte, error) {
@@ -325,158 +188,45 @@ func scenarioBytes(scenario map[string]interface{}) ([]byte, error) {
 	return []byte(value), nil
 }
 
-func uploadMetadata(
-	scenario map[string]interface{},
-	createResponse map[string]interface{},
-) (map[string]string, error) {
-	upload, err := objectValue(scenario["upload"], "upload")
-	if err != nil {
-		return nil, err
-	}
-	fields, err := arrayValue(upload["metadata"], "upload.metadata")
-	if err != nil {
-		return nil, err
-	}
-
-	context := map[string]interface{}{
-		"createResponse": createResponse,
-		"scenario":       scenario,
-	}
-	metadata := map[string]string{}
-	for index, rawField := range fields {
-		label := fmt.Sprintf("upload.metadata[%d]", index)
-		field, err := objectValue(rawField, label)
-		if err != nil {
-			return nil, err
-		}
-		name, err := stringValue(field["name"], label+".name")
-		if err != nil {
-			return nil, err
-		}
-		value, err := resolveValue(field["value"], context, label+".value")
-		if err != nil {
-			return nil, err
-		}
-		metadata[name] = scalarString(value)
-	}
-
-	return metadata, nil
-}
-
-func tusMetadataHeader(metadata map[string]string) string {
-	parts := make([]string, 0, len(metadata))
-	for name, value := range metadata {
-		encoded := base64.StdEncoding.EncodeToString([]byte(value))
-		parts = append(parts, fmt.Sprintf("%s %s", name, encoded))
-	}
-
-	return strings.Join(parts, ",")
-}
-
-func checkedResponse(response *http.Response, expectedStatus int, label string) error {
-	defer response.Body.Close()
-	if response.StatusCode == expectedStatus {
-		return nil
-	}
-
-	body, _ := ioutil.ReadAll(response.Body)
-	return fmt.Errorf("%s returned HTTP %d: %s", label, response.StatusCode, string(body))
-}
-
-func uploadWithTus(
-	ctx context.Context,
-	scenario map[string]interface{},
-	createResponse map[string]interface{},
-) (string, error) {
+func uploadInfo(scenario map[string]interface{}) (string, string, map[string]string, error) {
 	uploadConfig, err := objectValue(scenario["upload"], "upload")
 	if err != nil {
-		return "", err
-	}
-	context := map[string]interface{}{
-		"createResponse": createResponse,
-		"scenario":       scenario,
-	}
-	endpointValue, err := resolveValue(uploadConfig["tusUrl"], context, "upload.tusUrl")
-	if err != nil {
-		return "", err
-	}
-	endpointURL, err := url.Parse(scalarString(endpointValue))
-	if err != nil {
-		return "", err
-	}
-	content, err := scenarioBytes(scenario)
-	if err != nil {
-		return "", err
+		return "", "", nil, err
 	}
 	chunkSize, err := stringValue(uploadConfig["chunkSize"], "upload.chunkSize")
 	if err != nil {
-		return "", err
+		return "", "", nil, err
 	}
 	if chunkSize != "full-file" {
-		return "", fmt.Errorf("unsupported chunk size policy %q", chunkSize)
+		return "", "", nil, fmt.Errorf("unsupported chunk size policy %q", chunkSize)
 	}
-	metadata, err := uploadMetadata(scenario, createResponse)
+	fieldName, err := stringValue(uploadConfig["fieldName"], "upload.fieldName")
 	if err != nil {
-		return "", err
+		return "", "", nil, err
+	}
+	fileName, err := stringValue(uploadConfig["fileName"], "upload.fileName")
+	if err != nil {
+		return "", "", nil, err
 	}
 
-	createRequest, err := http.NewRequestWithContext(ctx, http.MethodPost, endpointURL.String(), nil)
-	if err != nil {
-		return "", err
-	}
-	createRequest.Header.Set("Tus-Resumable", "1.0.0")
-	createRequest.Header.Set("Upload-Length", strconv.Itoa(len(content)))
-	createRequest.Header.Set("Upload-Metadata", tusMetadataHeader(metadata))
-
-	createResponseHttp, err := http.DefaultClient.Do(createRequest)
-	if err != nil {
-		return "", err
-	}
-	if err := checkedResponse(createResponseHttp, http.StatusCreated, "TUS create"); err != nil {
-		return "", err
-	}
-	location := createResponseHttp.Header.Get("Location")
-	if location == "" {
-		return "", fmt.Errorf("TUS create did not return a Location header")
-	}
-	uploadURL, err := endpointURL.Parse(location)
-	if err != nil {
-		return "", err
+	userMeta := map[string]string{}
+	if rawUserMeta, ok := uploadConfig["userMeta"]; ok {
+		userMetaObject, err := objectValue(rawUserMeta, "upload.userMeta")
+		if err != nil {
+			return "", "", nil, err
+		}
+		for name, value := range userMetaObject {
+			userMeta[name], err = stringValue(value, "upload.userMeta."+name)
+			if err != nil {
+				return "", "", nil, err
+			}
+		}
 	}
 
-	patchRequest, err := http.NewRequestWithContext(
-		ctx,
-		http.MethodPatch,
-		uploadURL.String(),
-		bytes.NewReader(content),
-	)
-	if err != nil {
-		return "", err
-	}
-	patchRequest.Header.Set("Tus-Resumable", "1.0.0")
-	patchRequest.Header.Set("Upload-Offset", "0")
-	patchRequest.Header.Set("Content-Type", "application/offset+octet-stream")
-
-	patchResponse, err := http.DefaultClient.Do(patchRequest)
-	if err != nil {
-		return "", err
-	}
-	if err := checkedResponse(patchResponse, http.StatusNoContent, "TUS upload"); err != nil {
-		return "", err
-	}
-	remoteOffset, err := intValue(patchResponse.Header.Get("Upload-Offset"), "Upload-Offset")
-	if err != nil {
-		return "", err
-	}
-	if remoteOffset != len(content) {
-		return "", fmt.Errorf("TUS upload offset %d, expected %d", remoteOffset, len(content))
-	}
-
-	return uploadURL.String(), nil
+	return fieldName, fileName, userMeta, nil
 }
 
 func writeResult(
-	createResponse map[string]interface{},
 	status map[string]interface{},
 	uploadURL string,
 ) error {
@@ -487,7 +237,7 @@ func writeResult(
 
 	contents, err := json.MarshalIndent(
 		map[string]interface{}{
-			"createResponse": createResponse,
+			"createResponse": status,
 			"status":         status,
 			"uploadUrl":      uploadURL,
 		},
@@ -516,23 +266,35 @@ func main() {
 		Endpoint:   requiredEnv("TRANSLOADIT_ENDPOINT"),
 	})
 
-	info, createResponse, err := createAssembly(ctx, client, scenario)
+	fileCount, err := scenarioFileCount(scenario)
 	if err != nil {
-		fail("create TUS assembly: %v", err)
+		fail("read file count: %v", err)
 	}
-	uploadURL, err := uploadWithTus(ctx, scenario, createResponse)
+	content, err := scenarioBytes(scenario)
 	if err != nil {
-		fail("upload: %v", err)
+		fail("read upload bytes: %v", err)
 	}
-	statusInfo, err := client.WaitForAssembly(ctx, info)
+	fieldName, fileName, userMeta, err := uploadInfo(scenario)
 	if err != nil {
-		fail("wait for assembly: %v", err)
+		fail("read upload info: %v", err)
+	}
+
+	statusInfo, uploadURL, err := client.UploadTusAssembly(
+		ctx,
+		fileCount,
+		content,
+		fieldName,
+		fileName,
+		userMeta,
+	)
+	if err != nil {
+		fail("upload TUS assembly: %v", err)
 	}
 	status, err := asJsonObject(statusInfo, "assembly status")
 	if err != nil {
 		fail("serialize assembly status: %v", err)
 	}
-	if err := writeResult(createResponse, status, uploadURL); err != nil {
+	if err := writeResult(status, uploadURL); err != nil {
 		fail("write result: %v", err)
 	}
 

--- a/examples/api2-devdock-tus-assembly/main.go
+++ b/examples/api2-devdock-tus-assembly/main.go
@@ -7,11 +7,31 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strconv"
 	"time"
 
 	transloadit "github.com/transloadit/go-sdk"
 )
+
+type tusAssemblyScenario struct {
+	ExampleInput struct {
+		ScenarioID       string `json:"scenarioId"`
+		SdkFeatureInputs struct {
+			UploadTusAssembly uploadTusAssemblyInput `json:"uploadTusAssembly"`
+		} `json:"sdkFeatureInputs"`
+	} `json:"exampleInput"`
+}
+
+type uploadTusAssemblyInput struct {
+	FileCount int          `json:"file_count"`
+	Upload    uploadConfig `json:"upload"`
+}
+
+type uploadConfig struct {
+	Content  string            `json:"content"`
+	Field    string            `json:"fieldname"`
+	Filename string            `json:"filename"`
+	UserMeta map[string]string `json:"user_meta"`
+}
 
 func requiredEnv(name string) string {
 	value := os.Getenv(name)
@@ -26,7 +46,7 @@ func fail(format string, args ...interface{}) {
 	panic(fmt.Sprintf(format, args...))
 }
 
-func loadScenario() (map[string]interface{}, error) {
+func loadScenario() (tusAssemblyScenario, error) {
 	scenarioPath := os.Getenv("API2_SDK_EXAMPLE_SCENARIO")
 	if scenarioPath == "" {
 		scenarioPath = filepath.Join("examples", "api2-devdock-tus-assembly", "api2-scenario.json")
@@ -34,100 +54,15 @@ func loadScenario() (map[string]interface{}, error) {
 
 	contents, err := ioutil.ReadFile(scenarioPath)
 	if err != nil {
-		return nil, err
+		return tusAssemblyScenario{}, err
 	}
 
-	var scenario map[string]interface{}
+	var scenario tusAssemblyScenario
 	if err := json.Unmarshal(contents, &scenario); err != nil {
-		return nil, err
+		return tusAssemblyScenario{}, err
 	}
 
 	return scenario, nil
-}
-
-func objectValue(value interface{}, label string) (map[string]interface{}, error) {
-	object, ok := value.(map[string]interface{})
-	if !ok {
-		return nil, fmt.Errorf("%s must be an object", label)
-	}
-
-	return object, nil
-}
-
-func arrayValue(value interface{}, label string) ([]interface{}, error) {
-	array, ok := value.([]interface{})
-	if !ok {
-		return nil, fmt.Errorf("%s must be an array", label)
-	}
-
-	return array, nil
-}
-
-func stringValue(value interface{}, label string) (string, error) {
-	text, ok := value.(string)
-	if !ok {
-		return "", fmt.Errorf("%s must be a string", label)
-	}
-
-	return text, nil
-}
-
-func intValue(value interface{}, label string) (int, error) {
-	switch number := value.(type) {
-	case float64:
-		if float64(int(number)) != number {
-			return 0, fmt.Errorf("%s must be an integer", label)
-		}
-
-		return int(number), nil
-	case int:
-		return number, nil
-	case string:
-		parsed, err := strconv.Atoi(number)
-		if err != nil {
-			return 0, fmt.Errorf("%s must be an integer", label)
-		}
-
-		return parsed, nil
-	default:
-		return 0, fmt.Errorf("%s must be an integer", label)
-	}
-}
-
-func sdkFeatureCall(
-	scenario map[string]interface{},
-	featureID string,
-) (map[string]interface{}, string, error) {
-	featureCalls, err := arrayValue(scenario["sdkFeatureCalls"], "sdkFeatureCalls")
-	if err != nil {
-		return nil, "", err
-	}
-
-	for index, rawFeatureCall := range featureCalls {
-		label := fmt.Sprintf("sdkFeatureCalls[%d]", index)
-		featureCall, err := objectValue(rawFeatureCall, label)
-		if err != nil {
-			return nil, "", err
-		}
-		currentFeatureID, err := stringValue(featureCall["featureId"], label+".featureId")
-		if err != nil {
-			return nil, "", err
-		}
-		if currentFeatureID != featureID {
-			continue
-		}
-		kind, err := stringValue(featureCall["kind"], label+".kind")
-		if err != nil {
-			return nil, "", err
-		}
-		if kind != "sdk-feature-call" {
-			return nil, "", fmt.Errorf("%s must be an sdk-feature-call", label)
-		}
-
-		return featureCall, label, nil
-	}
-
-	return nil, "", fmt.Errorf("scenario has no SDK feature call for feature %q", featureID)
 }
 
 func asJsonObject(value interface{}, label string) (map[string]interface{}, error) {
@@ -142,81 +77,6 @@ func asJsonObject(value interface{}, label string) (map[string]interface{}, erro
 	}
 
 	return result, nil
-}
-
-func uploadTusAssemblyInput(scenario map[string]interface{}) (map[string]interface{}, error) {
-	featureCall, featureCallLabel, err := sdkFeatureCall(scenario, "uploadTusAssembly")
-	if err != nil {
-		return nil, err
-	}
-	input, err := objectValue(featureCall["input"], featureCallLabel+".input")
-	if err != nil {
-		return nil, err
-	}
-
-	return input, nil
-}
-
-func scenarioFileCount(input map[string]interface{}) (int, error) {
-	return intValue(input["file_count"], "sdkFeatureCalls.uploadTusAssembly.input.file_count")
-}
-
-func scenarioBytes(uploadConfig map[string]interface{}) ([]byte, error) {
-	content, err := stringValue(
-		uploadConfig["content"],
-		"sdkFeatureCalls.uploadTusAssembly.input.upload.content",
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	return []byte(content), nil
-}
-
-func uploadInfo(input map[string]interface{}) (string, string, map[string]string, error) {
-	uploadConfig, err := objectValue(
-		input["upload"],
-		"sdkFeatureCalls.uploadTusAssembly.input.upload",
-	)
-	if err != nil {
-		return "", "", nil, err
-	}
-	fieldName, err := stringValue(
-		uploadConfig["fieldname"],
-		"sdkFeatureCalls.uploadTusAssembly.input.upload.fieldname",
-	)
-	if err != nil {
-		return "", "", nil, err
-	}
-	fileName, err := stringValue(
-		uploadConfig["filename"],
-		"sdkFeatureCalls.uploadTusAssembly.input.upload.filename",
-	)
-	if err != nil {
-		return "", "", nil, err
-	}
-
-	userMeta := map[string]string{}
-	if rawUserMeta, ok := uploadConfig["user_meta"]; ok {
-		userMetaObject, err := objectValue(
-			rawUserMeta,
-			"sdkFeatureCalls.uploadTusAssembly.input.upload.user_meta",
-		)
-		if err != nil {
-			return "", "", nil, err
-		}
-		for name, value := range userMetaObject {
-			userMeta[name], err = stringValue(
-				value,
-				"sdkFeatureCalls.uploadTusAssembly.input.upload.user_meta."+name,
-			)
-			if err != nil {
-				return "", "", nil, err
-			}
-		}
-	}
-
-	return fieldName, fileName, userMeta, nil
 }
 
 func writeResult(
@@ -252,10 +112,7 @@ func main() {
 	if err != nil {
 		fail("load scenario: %v", err)
 	}
-	input, err := uploadTusAssemblyInput(scenario)
-	if err != nil {
-		fail("read SDK feature call input: %v", err)
-	}
+	input := scenario.ExampleInput.SdkFeatureInputs.UploadTusAssembly
 
 	client := transloadit.NewClient(transloadit.Config{
 		AuthKey:    requiredEnv("TRANSLOADIT_KEY"),
@@ -263,32 +120,17 @@ func main() {
 		Endpoint:   requiredEnv("TRANSLOADIT_ENDPOINT"),
 	})
 
-	fileCount, err := scenarioFileCount(input)
-	if err != nil {
-		fail("read file count: %v", err)
-	}
-	fieldName, fileName, userMeta, err := uploadInfo(input)
-	if err != nil {
-		fail("read upload info: %v", err)
-	}
-	uploadConfig, err := objectValue(
-		input["upload"],
-		"sdkFeatureCalls.uploadTusAssembly.input.upload",
-	)
-	if err != nil {
-		fail("read upload config: %v", err)
-	}
-	content, err := scenarioBytes(uploadConfig)
-	if err != nil {
-		fail("read upload bytes: %v", err)
+	userMeta := input.Upload.UserMeta
+	if userMeta == nil {
+		userMeta = map[string]string{}
 	}
 
 	statusInfo, uploadURL, err := client.UploadTusAssembly(
 		ctx,
-		fileCount,
-		content,
-		fieldName,
-		fileName,
+		input.FileCount,
+		[]byte(input.Upload.Content),
+		input.Upload.Field,
+		input.Upload.Filename,
 		userMeta,
 	)
 	if err != nil {
@@ -302,9 +144,9 @@ func main() {
 		fail("write result: %v", err)
 	}
 
-	scenarioID, err := stringValue(scenario["scenarioId"], "scenarioId")
-	if err != nil {
-		fail("read scenario id: %v", err)
-	}
-	fmt.Printf("Go Transloadit SDK devdock scenario %s uploaded to %s\n", scenarioID, uploadURL)
+	fmt.Printf(
+		"Go Transloadit SDK devdock scenario %s uploaded to %s\n",
+		scenario.ExampleInput.ScenarioID,
+		uploadURL,
+	)
 }

--- a/examples/api2-devdock-tus-assembly/main.go
+++ b/examples/api2-devdock-tus-assembly/main.go
@@ -94,40 +94,40 @@ func intValue(value interface{}, label string) (int, error) {
 	}
 }
 
-func featurePreparation(
+func sdkFeatureCall(
 	scenario map[string]interface{},
 	featureID string,
 ) (map[string]interface{}, string, error) {
-	preparations, err := arrayValue(scenario["preparations"], "preparations")
+	featureCalls, err := arrayValue(scenario["sdkFeatureCalls"], "sdkFeatureCalls")
 	if err != nil {
 		return nil, "", err
 	}
 
-	for index, rawPreparation := range preparations {
-		label := fmt.Sprintf("preparations[%d]", index)
-		preparation, err := objectValue(rawPreparation, label)
+	for index, rawFeatureCall := range featureCalls {
+		label := fmt.Sprintf("sdkFeatureCalls[%d]", index)
+		featureCall, err := objectValue(rawFeatureCall, label)
 		if err != nil {
 			return nil, "", err
 		}
-		currentFeatureID, err := stringValue(preparation["featureId"], label+".featureId")
+		currentFeatureID, err := stringValue(featureCall["featureId"], label+".featureId")
 		if err != nil {
 			return nil, "", err
 		}
 		if currentFeatureID != featureID {
 			continue
 		}
-		kind, err := stringValue(preparation["kind"], label+".kind")
+		kind, err := stringValue(featureCall["kind"], label+".kind")
 		if err != nil {
 			return nil, "", err
 		}
-		if kind != "feature-call" {
-			return nil, "", fmt.Errorf("%s must be a feature-call preparation", label)
+		if kind != "sdk-feature-call" {
+			return nil, "", fmt.Errorf("%s must be an sdk-feature-call", label)
 		}
 
-		return preparation, label, nil
+		return featureCall, label, nil
 	}
 
-	return nil, "", fmt.Errorf("scenario has no preparation for feature %q", featureID)
+	return nil, "", fmt.Errorf("scenario has no SDK feature call for feature %q", featureID)
 }
 
 func asJsonObject(value interface{}, label string) (map[string]interface{}, error) {
@@ -144,79 +144,72 @@ func asJsonObject(value interface{}, label string) (map[string]interface{}, erro
 	return result, nil
 }
 
-func scenarioFileCount(scenario map[string]interface{}) (int, error) {
-	createConfig, createConfigLabel, err := featurePreparation(scenario, "createTusAssembly")
+func uploadTusAssemblyInput(scenario map[string]interface{}) (map[string]interface{}, error) {
+	featureCall, featureCallLabel, err := sdkFeatureCall(scenario, "uploadTusAssembly")
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
-	input, err := objectValue(createConfig["input"], createConfigLabel+".input")
+	input, err := objectValue(featureCall["input"], featureCallLabel+".input")
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
 
-	return intValue(input["file_count"], createConfigLabel+".input.file_count")
+	return input, nil
 }
 
-func scenarioBytes(scenario map[string]interface{}) ([]byte, error) {
-	upload, err := objectValue(scenario["upload"], "upload")
-	if err != nil {
-		return nil, err
-	}
-	source, err := objectValue(upload["source"], "upload.source")
-	if err != nil {
-		return nil, err
-	}
-	kind, err := stringValue(source["kind"], "upload.source.kind")
-	if err != nil {
-		return nil, err
-	}
-	if kind != "bytes" {
-		return nil, fmt.Errorf("unsupported scenario source kind %q", kind)
-	}
-	encoding, err := stringValue(source["encoding"], "upload.source.encoding")
-	if err != nil {
-		return nil, err
-	}
-	if encoding != "utf8" {
-		return nil, fmt.Errorf("unsupported scenario source encoding %q", encoding)
-	}
-	value, err := stringValue(source["value"], "upload.source.value")
-	if err != nil {
-		return nil, err
-	}
-
-	return []byte(value), nil
+func scenarioFileCount(input map[string]interface{}) (int, error) {
+	return intValue(input["file_count"], "sdkFeatureCalls.uploadTusAssembly.input.file_count")
 }
 
-func uploadInfo(scenario map[string]interface{}) (string, string, map[string]string, error) {
-	uploadConfig, err := objectValue(scenario["upload"], "upload")
+func scenarioBytes(uploadConfig map[string]interface{}) ([]byte, error) {
+	content, err := stringValue(
+		uploadConfig["content"],
+		"sdkFeatureCalls.uploadTusAssembly.input.upload.content",
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return []byte(content), nil
+}
+
+func uploadInfo(input map[string]interface{}) (string, string, map[string]string, error) {
+	uploadConfig, err := objectValue(
+		input["upload"],
+		"sdkFeatureCalls.uploadTusAssembly.input.upload",
+	)
 	if err != nil {
 		return "", "", nil, err
 	}
-	chunkSize, err := stringValue(uploadConfig["chunkSize"], "upload.chunkSize")
+	fieldName, err := stringValue(
+		uploadConfig["fieldname"],
+		"sdkFeatureCalls.uploadTusAssembly.input.upload.fieldname",
+	)
 	if err != nil {
 		return "", "", nil, err
 	}
-	if chunkSize != "full-file" {
-		return "", "", nil, fmt.Errorf("unsupported chunk size policy %q", chunkSize)
-	}
-	fieldName, err := stringValue(uploadConfig["fieldName"], "upload.fieldName")
-	if err != nil {
-		return "", "", nil, err
-	}
-	fileName, err := stringValue(uploadConfig["fileName"], "upload.fileName")
+	fileName, err := stringValue(
+		uploadConfig["filename"],
+		"sdkFeatureCalls.uploadTusAssembly.input.upload.filename",
+	)
 	if err != nil {
 		return "", "", nil, err
 	}
 
 	userMeta := map[string]string{}
-	if rawUserMeta, ok := uploadConfig["userMeta"]; ok {
-		userMetaObject, err := objectValue(rawUserMeta, "upload.userMeta")
+	if rawUserMeta, ok := uploadConfig["user_meta"]; ok {
+		userMetaObject, err := objectValue(
+			rawUserMeta,
+			"sdkFeatureCalls.uploadTusAssembly.input.upload.user_meta",
+		)
 		if err != nil {
 			return "", "", nil, err
 		}
 		for name, value := range userMetaObject {
-			userMeta[name], err = stringValue(value, "upload.userMeta."+name)
+			userMeta[name], err = stringValue(
+				value,
+				"sdkFeatureCalls.uploadTusAssembly.input.upload.user_meta."+name,
+			)
 			if err != nil {
 				return "", "", nil, err
 			}
@@ -259,6 +252,10 @@ func main() {
 	if err != nil {
 		fail("load scenario: %v", err)
 	}
+	input, err := uploadTusAssemblyInput(scenario)
+	if err != nil {
+		fail("read SDK feature call input: %v", err)
+	}
 
 	client := transloadit.NewClient(transloadit.Config{
 		AuthKey:    requiredEnv("TRANSLOADIT_KEY"),
@@ -266,17 +263,24 @@ func main() {
 		Endpoint:   requiredEnv("TRANSLOADIT_ENDPOINT"),
 	})
 
-	fileCount, err := scenarioFileCount(scenario)
+	fileCount, err := scenarioFileCount(input)
 	if err != nil {
 		fail("read file count: %v", err)
 	}
-	content, err := scenarioBytes(scenario)
-	if err != nil {
-		fail("read upload bytes: %v", err)
-	}
-	fieldName, fileName, userMeta, err := uploadInfo(scenario)
+	fieldName, fileName, userMeta, err := uploadInfo(input)
 	if err != nil {
 		fail("read upload info: %v", err)
+	}
+	uploadConfig, err := objectValue(
+		input["upload"],
+		"sdkFeatureCalls.uploadTusAssembly.input.upload",
+	)
+	if err != nil {
+		fail("read upload config: %v", err)
+	}
+	content, err := scenarioBytes(uploadConfig)
+	if err != nil {
+		fail("read upload bytes: %v", err)
 	}
 
 	statusInfo, uploadURL, err := client.UploadTusAssembly(

--- a/examples/api2-devdock-tus-resume-upload/main.go
+++ b/examples/api2-devdock-tus-resume-upload/main.go
@@ -1,0 +1,329 @@
+// Run the API2 contract TUS resume scenario against a devdock API2 server.
+//
+// This example is intentionally checked into the SDK repository: it reads the
+// API/TUS facts from API2's injected scenario JSON, interrupts an upload like
+// an unlucky user would, and resumes it through the public SDK method.
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	transloadit "github.com/transloadit/go-sdk"
+)
+
+type resumeUploadScenario struct {
+	ExampleInput struct {
+		ScenarioID string `json:"scenarioId"`
+	} `json:"exampleInput"`
+	Prepared struct {
+		CreateResponse map[string]interface{} `json:"createResponse"`
+	} `json:"prepared"`
+	Upload struct {
+		Metadata []metadataField `json:"metadata"`
+		Resume   resumePlan      `json:"resume"`
+		Source   uploadSource    `json:"source"`
+		TusURL   valueSpec       `json:"tusUrl"`
+	} `json:"upload"`
+}
+
+type metadataField struct {
+	Name  string    `json:"name"`
+	Value valueSpec `json:"value"`
+}
+
+type resumePlan struct {
+	Fingerprint                string `json:"fingerprint"`
+	RemoveFingerprintOnSuccess bool   `json:"removeFingerprintOnSuccess"`
+	StopAfterAcceptedBytes     int    `json:"stopAfterAcceptedBytes"`
+}
+
+type uploadSource struct {
+	Encoding string `json:"encoding"`
+	Kind     string `json:"kind"`
+	Value    string `json:"value"`
+}
+
+type valueSpec struct {
+	Source *valueSpecSource `json:"source"`
+	Value  interface{}      `json:"value"`
+}
+
+type valueSpecSource struct {
+	Path []string `json:"path"`
+	Root string   `json:"root"`
+}
+
+func requiredEnv(name string) string {
+	value := os.Getenv(name)
+	if value == "" {
+		panic(fmt.Sprintf("%s must be set", name))
+	}
+
+	return value
+}
+
+func fail(format string, args ...interface{}) {
+	panic(fmt.Sprintf(format, args...))
+}
+
+func loadScenario() (resumeUploadScenario, map[string]interface{}, error) {
+	scenarioPath := os.Getenv("API2_SDK_EXAMPLE_SCENARIO")
+	if scenarioPath == "" {
+		scenarioPath = filepath.Join("examples", "api2-devdock-tus-resume-upload", "api2-scenario.json")
+	}
+
+	contents, err := ioutil.ReadFile(scenarioPath)
+	if err != nil {
+		return resumeUploadScenario{}, nil, err
+	}
+
+	var scenario resumeUploadScenario
+	if err := json.Unmarshal(contents, &scenario); err != nil {
+		return resumeUploadScenario{}, nil, err
+	}
+
+	var rawScenario map[string]interface{}
+	if err := json.Unmarshal(contents, &rawScenario); err != nil {
+		return resumeUploadScenario{}, nil, err
+	}
+
+	return scenario, rawScenario, nil
+}
+
+func resolveValue(spec valueSpec, context map[string]interface{}, label string) interface{} {
+	if spec.Source == nil {
+		return spec.Value
+	}
+
+	current, ok := context[spec.Source.Root]
+	if !ok {
+		fail("%s value source root is unavailable", label)
+	}
+	for _, part := range spec.Source.Path {
+		record, ok := current.(map[string]interface{})
+		if !ok {
+			fail("%s value source cannot read %s", label, part)
+		}
+		current, ok = record[part]
+		if !ok {
+			fail("%s value source cannot read %s", label, part)
+		}
+	}
+
+	return current
+}
+
+func resolveString(spec valueSpec, context map[string]interface{}, label string) string {
+	value, ok := resolveValue(spec, context, label).(string)
+	if !ok {
+		fail("%s must be a string", label)
+	}
+
+	return value
+}
+
+func scenarioBytes(source uploadSource) []byte {
+	if source.Kind != "bytes" {
+		fail("upload.source.kind must be bytes")
+	}
+	if source.Encoding != "utf8" {
+		fail("upload.source.encoding must be utf8")
+	}
+
+	return []byte(source.Value)
+}
+
+func uploadMetadata(fields []metadataField, context map[string]interface{}) map[string]string {
+	metadata := make(map[string]string, len(fields))
+	for _, field := range fields {
+		metadata[field.Name] = fmt.Sprintf("%v", resolveValue(field.Value, context, field.Name))
+	}
+
+	return metadata
+}
+
+// createInterruptedUpload creates a TUS upload and only sends the first chunk,
+// leaving the upload interrupted the way a dropped connection would.
+func createInterruptedUpload(
+	ctx context.Context,
+	tusURL string,
+	content []byte,
+	metadata map[string]string,
+	stopAfterAcceptedBytes int,
+) string {
+	metadataNames := make([]string, 0, len(metadata))
+	for name := range metadata {
+		metadataNames = append(metadataNames, name)
+	}
+	sort.Strings(metadataNames)
+	metadataParts := make([]string, 0, len(metadata))
+	for _, name := range metadataNames {
+		encodedValue := base64.StdEncoding.EncodeToString([]byte(metadata[name]))
+		metadataParts = append(metadataParts, fmt.Sprintf("%s %s", name, encodedValue))
+	}
+
+	createRequest, err := http.NewRequestWithContext(ctx, "POST", tusURL, nil)
+	if err != nil {
+		fail("TUS create request: %v", err)
+	}
+	createRequest.Header.Set("Tus-Resumable", "1.0.0")
+	createRequest.Header.Set("Upload-Length", strconv.Itoa(len(content)))
+	createRequest.Header.Set("Upload-Metadata", strings.Join(metadataParts, ","))
+	createResponse, err := http.DefaultClient.Do(createRequest)
+	if err != nil {
+		fail("TUS create request failed: %v", err)
+	}
+	defer createResponse.Body.Close()
+	if createResponse.StatusCode != 201 {
+		fail("TUS create returned HTTP %d, expected 201", createResponse.StatusCode)
+	}
+	location := createResponse.Header.Get("Location")
+	if location == "" {
+		fail("TUS create did not return a Location header")
+	}
+	tusBase, err := url.Parse(tusURL)
+	if err != nil {
+		fail("parse TUS URL: %v", err)
+	}
+	uploadURL, err := tusBase.Parse(location)
+	if err != nil {
+		fail("resolve upload URL: %v", err)
+	}
+	uploadURLText := uploadURL.String()
+
+	patchRequest, err := http.NewRequestWithContext(
+		ctx,
+		"PATCH",
+		uploadURLText,
+		bytes.NewReader(content[:stopAfterAcceptedBytes]),
+	)
+	if err != nil {
+		fail("TUS first chunk request: %v", err)
+	}
+	patchRequest.Header.Set("Tus-Resumable", "1.0.0")
+	patchRequest.Header.Set("Upload-Offset", "0")
+	patchRequest.Header.Set("Content-Type", "application/offset+octet-stream")
+	patchResponse, err := http.DefaultClient.Do(patchRequest)
+	if err != nil {
+		fail("TUS first chunk request failed: %v", err)
+	}
+	defer patchResponse.Body.Close()
+	if patchResponse.StatusCode != 204 {
+		fail("TUS first chunk returned HTTP %d, expected 204", patchResponse.StatusCode)
+	}
+	acceptedBytes, err := strconv.Atoi(patchResponse.Header.Get("Upload-Offset"))
+	if err != nil || acceptedBytes != stopAfterAcceptedBytes {
+		fail("TUS first chunk accepted %d bytes, expected %d", acceptedBytes, stopAfterAcceptedBytes)
+	}
+
+	return uploadURLText
+}
+
+func writeResult(
+	firstUploadURL string,
+	previousUploadCount int,
+	remainingPreviousUploadCount int,
+) error {
+	resultPath := os.Getenv("API2_SDK_EXAMPLE_RESULT")
+	if resultPath == "" {
+		return nil
+	}
+
+	contents, err := json.MarshalIndent(
+		map[string]interface{}{
+			"firstUploadUrl":               firstUploadURL,
+			"previousUploadCount":          previousUploadCount,
+			"remainingPreviousUploadCount": remainingPreviousUploadCount,
+			"uploadUrl":                    firstUploadURL,
+		},
+		"",
+		"  ",
+	)
+	if err != nil {
+		return err
+	}
+
+	return ioutil.WriteFile(resultPath, append(contents, '\n'), 0o644)
+}
+
+func main() {
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	scenario, rawScenario, err := loadScenario()
+	if err != nil {
+		fail("load scenario: %v", err)
+	}
+	resume := scenario.Upload.Resume
+
+	client := transloadit.NewClient(transloadit.Config{
+		AuthKey:    requiredEnv("TRANSLOADIT_KEY"),
+		AuthSecret: requiredEnv("TRANSLOADIT_SECRET"),
+		Endpoint:   requiredEnv("TRANSLOADIT_ENDPOINT"),
+	})
+
+	valueContext := map[string]interface{}{
+		"createResponse": scenario.Prepared.CreateResponse,
+		"scenario":       rawScenario,
+	}
+	content := scenarioBytes(scenario.Upload.Source)
+	tusURL := resolveString(scenario.Upload.TusURL, valueContext, "upload.tusUrl")
+	metadata := uploadMetadata(scenario.Upload.Metadata, valueContext)
+
+	firstUploadURL := createInterruptedUpload(
+		ctx,
+		tusURL,
+		content,
+		metadata,
+		resume.StopAfterAcceptedBytes,
+	)
+
+	// Remember the interrupted upload by fingerprint, like a TUS client URL storage would.
+	storedUploads := map[string]string{resume.Fingerprint: firstUploadURL}
+	previousUploadCount := len(storedUploads)
+
+	assemblySSLURL, ok := scenario.Prepared.CreateResponse["assembly_ssl_url"].(string)
+	if !ok || assemblySSLURL == "" {
+		fail("prepared.createResponse.assembly_ssl_url must be a string")
+	}
+	completedAssembly, err := client.ResumeTusUpload(
+		ctx,
+		storedUploads[resume.Fingerprint],
+		content,
+		&transloadit.AssemblyInfo{AssemblySSLURL: assemblySSLURL},
+	)
+	if err != nil {
+		fail("resume TUS upload: %v", err)
+	}
+	if completedAssembly.Error != "" {
+		fail("resumeTusUpload returned %s: %s", completedAssembly.Error, completedAssembly.Message)
+	}
+
+	if resume.RemoveFingerprintOnSuccess {
+		delete(storedUploads, resume.Fingerprint)
+	}
+	remainingPreviousUploadCount := len(storedUploads)
+
+	if err := writeResult(firstUploadURL, previousUploadCount, remainingPreviousUploadCount); err != nil {
+		fail("write result: %v", err)
+	}
+
+	fmt.Printf(
+		"Go Transloadit SDK devdock scenario %s resumed %s\n",
+		scenario.ExampleInput.ScenarioID,
+		firstUploadURL,
+	)
+}

--- a/notification.go
+++ b/notification.go
@@ -34,6 +34,8 @@ func (client *Client) ListNotifications(ctx context.Context, options *ListOption
 	return list, errors.New("transloadit: listing assembly notifications is no longer available")
 }
 
+// <api2-generated-endpoint replayAssemblyNotification>
+
 // ReplayNotification instructs the endpoint to replay the notification
 // corresponding to the provided assembly ID.
 // If notifyURL is not empty it will override the notify URL used in the
@@ -47,3 +49,5 @@ func (client *Client) ReplayNotification(ctx context.Context, assemblyID string,
 
 	return client.request(ctx, "POST", "assembly_notifications/"+assemblyID+"/replay", params, nil)
 }
+
+// </api2-generated-endpoint replayAssemblyNotification>

--- a/notification.go
+++ b/notification.go
@@ -36,6 +36,10 @@ func (client *Client) ListNotifications(ctx context.Context, options *ListOption
 
 // <api2-generated-endpoint replayAssemblyNotification>
 
+// This block is generated from Transloadit API2 contracts. If it looks wrong,
+// please report the issue instead of editing this block by hand; the source fix
+// belongs in the contract generator so all SDKs stay in sync.
+
 // ReplayNotification instructs the endpoint to replay the notification
 // corresponding to the provided assembly ID.
 // If notifyURL is not empty it will override the notify URL used in the

--- a/notification.go
+++ b/notification.go
@@ -51,7 +51,7 @@ func (client *Client) ReplayNotification(ctx context.Context, assemblyID string,
 		params["notify_url"] = notifyURL
 	}
 
-	return client.request(ctx, "POST", "assembly_notifications/"+assemblyID+"/replay", params, nil)
+	return client.request(ctx, "POST", "assembly_notifications/"+escapePathSegment(assemblyID)+"/replay", params, nil)
 }
 
 // </api2-generated-endpoint replayAssemblyNotification>

--- a/notification.go
+++ b/notification.go
@@ -45,6 +45,10 @@ func (client *Client) ListNotifications(ctx context.Context, options *ListOption
 // If notifyURL is not empty it will override the notify URL used in the
 // assembly instructions.
 func (client *Client) ReplayNotification(ctx context.Context, assemblyID string, notifyURL string) error {
+	if err := validatePathSegment(assemblyID); err != nil {
+		return err
+	}
+
 	params := make(map[string]interface{})
 
 	if notifyURL != "" {

--- a/template.go
+++ b/template.go
@@ -164,6 +164,7 @@ func (client *Client) CreateTemplate(ctx context.Context, template Template) (st
 	return template.ID, nil
 }
 
+// <api2-generated-endpoint getTemplate>
 // GetTemplate will retrieve details about the template associated with the
 // provided template ID.
 func (client *Client) GetTemplate(ctx context.Context, templateID string) (template Template, err error) {
@@ -171,11 +172,16 @@ func (client *Client) GetTemplate(ctx context.Context, templateID string) (templ
 	return template, err
 }
 
+// </api2-generated-endpoint getTemplate>
+
+// <api2-generated-endpoint deleteTemplate>
 // DeleteTemplate will delete the template associated with the provided
 // template ID.
 func (client *Client) DeleteTemplate(ctx context.Context, templateID string) error {
 	return client.request(ctx, "DELETE", "templates/"+templateID, nil, nil)
 }
+
+// </api2-generated-endpoint deleteTemplate>
 
 // UpdateTemplate will update the template associated with the provided
 // template ID to match the new name and  new content. Please be aware that you
@@ -195,8 +201,11 @@ func (client *Client) UpdateTemplate(ctx context.Context, templateID string, new
 	return client.request(ctx, "PUT", "templates/"+templateID, content, nil)
 }
 
+// <api2-generated-endpoint listTemplates>
 // ListTemplates will retrieve all templates matching the criteria.
 func (client *Client) ListTemplates(ctx context.Context, options *ListOptions) (list TemplateList, err error) {
 	err = client.listRequest(ctx, "templates", options, &list)
 	return list, err
 }
+
+// </api2-generated-endpoint listTemplates>

--- a/template.go
+++ b/template.go
@@ -148,6 +148,10 @@ func (template *Template) UnmarshalJSON(b []byte) error {
 
 // <api2-generated-endpoint createTemplate>
 
+// This block is generated from Transloadit API2 contracts. If it looks wrong,
+// please report the issue instead of editing this block by hand; the source fix
+// belongs in the contract generator so all SDKs stay in sync.
+
 // CreateTemplate will save the provided template struct as a new template
 // and return the ID of the new template.
 func (client *Client) CreateTemplate(ctx context.Context, template Template) (string, error) {
@@ -170,6 +174,10 @@ func (client *Client) CreateTemplate(ctx context.Context, template Template) (st
 
 // <api2-generated-endpoint getTemplate>
 
+// This block is generated from Transloadit API2 contracts. If it looks wrong,
+// please report the issue instead of editing this block by hand; the source fix
+// belongs in the contract generator so all SDKs stay in sync.
+
 // GetTemplate will retrieve details about the template associated with the
 // provided template ID.
 func (client *Client) GetTemplate(ctx context.Context, templateID string) (template Template, err error) {
@@ -181,6 +189,10 @@ func (client *Client) GetTemplate(ctx context.Context, templateID string) (templ
 
 // <api2-generated-endpoint deleteTemplate>
 
+// This block is generated from Transloadit API2 contracts. If it looks wrong,
+// please report the issue instead of editing this block by hand; the source fix
+// belongs in the contract generator so all SDKs stay in sync.
+
 // DeleteTemplate will delete the template associated with the provided
 // template ID.
 func (client *Client) DeleteTemplate(ctx context.Context, templateID string) error {
@@ -190,6 +202,10 @@ func (client *Client) DeleteTemplate(ctx context.Context, templateID string) err
 // </api2-generated-endpoint deleteTemplate>
 
 // <api2-generated-endpoint updateTemplate>
+
+// This block is generated from Transloadit API2 contracts. If it looks wrong,
+// please report the issue instead of editing this block by hand; the source fix
+// belongs in the contract generator so all SDKs stay in sync.
 
 // UpdateTemplate will update the template associated with the provided
 // template ID to match the new name and  new content. Please be aware that you
@@ -212,6 +228,10 @@ func (client *Client) UpdateTemplate(ctx context.Context, templateID string, new
 // </api2-generated-endpoint updateTemplate>
 
 // <api2-generated-endpoint listTemplates>
+
+// This block is generated from Transloadit API2 contracts. If it looks wrong,
+// please report the issue instead of editing this block by hand; the source fix
+// belongs in the contract generator so all SDKs stay in sync.
 
 // ListTemplates will retrieve all templates matching the criteria.
 func (client *Client) ListTemplates(ctx context.Context, options *ListOptions) (list TemplateList, err error) {

--- a/template.go
+++ b/template.go
@@ -146,6 +146,8 @@ func (template *Template) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+// <api2-generated-endpoint createTemplate>
+
 // CreateTemplate will save the provided template struct as a new template
 // and return the ID of the new template.
 func (client *Client) CreateTemplate(ctx context.Context, template Template) (string, error) {
@@ -164,7 +166,10 @@ func (client *Client) CreateTemplate(ctx context.Context, template Template) (st
 	return template.ID, nil
 }
 
+// </api2-generated-endpoint createTemplate>
+
 // <api2-generated-endpoint getTemplate>
+
 // GetTemplate will retrieve details about the template associated with the
 // provided template ID.
 func (client *Client) GetTemplate(ctx context.Context, templateID string) (template Template, err error) {
@@ -175,6 +180,7 @@ func (client *Client) GetTemplate(ctx context.Context, templateID string) (templ
 // </api2-generated-endpoint getTemplate>
 
 // <api2-generated-endpoint deleteTemplate>
+
 // DeleteTemplate will delete the template associated with the provided
 // template ID.
 func (client *Client) DeleteTemplate(ctx context.Context, templateID string) error {
@@ -182,6 +188,8 @@ func (client *Client) DeleteTemplate(ctx context.Context, templateID string) err
 }
 
 // </api2-generated-endpoint deleteTemplate>
+
+// <api2-generated-endpoint updateTemplate>
 
 // UpdateTemplate will update the template associated with the provided
 // template ID to match the new name and  new content. Please be aware that you
@@ -201,7 +209,10 @@ func (client *Client) UpdateTemplate(ctx context.Context, templateID string, new
 	return client.request(ctx, "PUT", "templates/"+templateID, content, nil)
 }
 
+// </api2-generated-endpoint updateTemplate>
+
 // <api2-generated-endpoint listTemplates>
+
 // ListTemplates will retrieve all templates matching the criteria.
 func (client *Client) ListTemplates(ctx context.Context, options *ListOptions) (list TemplateList, err error) {
 	err = client.listRequest(ctx, "templates", options, &list)

--- a/template.go
+++ b/template.go
@@ -181,7 +181,7 @@ func (client *Client) CreateTemplate(ctx context.Context, template Template) (st
 // GetTemplate will retrieve details about the template associated with the
 // provided template ID.
 func (client *Client) GetTemplate(ctx context.Context, templateID string) (template Template, err error) {
-	err = client.request(ctx, "GET", "templates/"+templateID, nil, &template)
+	err = client.request(ctx, "GET", "templates/"+escapePathSegment(templateID), nil, &template)
 	return template, err
 }
 
@@ -196,7 +196,7 @@ func (client *Client) GetTemplate(ctx context.Context, templateID string) (templ
 // DeleteTemplate will delete the template associated with the provided
 // template ID.
 func (client *Client) DeleteTemplate(ctx context.Context, templateID string) error {
-	return client.request(ctx, "DELETE", "templates/"+templateID, nil, nil)
+	return client.request(ctx, "DELETE", "templates/"+escapePathSegment(templateID), nil, nil)
 }
 
 // </api2-generated-endpoint deleteTemplate>
@@ -222,7 +222,7 @@ func (client *Client) UpdateTemplate(ctx context.Context, templateID string, new
 		content["require_signature_auth"] = 0
 	}
 
-	return client.request(ctx, "PUT", "templates/"+templateID, content, nil)
+	return client.request(ctx, "PUT", "templates/"+escapePathSegment(templateID), content, nil)
 }
 
 // </api2-generated-endpoint updateTemplate>

--- a/template.go
+++ b/template.go
@@ -181,6 +181,10 @@ func (client *Client) CreateTemplate(ctx context.Context, template Template) (st
 // GetTemplate will retrieve details about the template associated with the
 // provided template ID.
 func (client *Client) GetTemplate(ctx context.Context, templateID string) (template Template, err error) {
+	if err := validatePathSegment(templateID); err != nil {
+		return Template{}, err
+	}
+
 	err = client.request(ctx, "GET", "templates/"+escapePathSegment(templateID), nil, &template)
 	return template, err
 }
@@ -196,6 +200,10 @@ func (client *Client) GetTemplate(ctx context.Context, templateID string) (templ
 // DeleteTemplate will delete the template associated with the provided
 // template ID.
 func (client *Client) DeleteTemplate(ctx context.Context, templateID string) error {
+	if err := validatePathSegment(templateID); err != nil {
+		return err
+	}
+
 	return client.request(ctx, "DELETE", "templates/"+escapePathSegment(templateID), nil, nil)
 }
 
@@ -211,6 +219,10 @@ func (client *Client) DeleteTemplate(ctx context.Context, templateID string) err
 // template ID to match the new name and  new content. Please be aware that you
 // are not able to change a template's ID.
 func (client *Client) UpdateTemplate(ctx context.Context, templateID string, newTemplate Template) error {
+	if err := validatePathSegment(templateID); err != nil {
+		return err
+	}
+
 	// Create signature
 	content := map[string]interface{}{
 		"name":     newTemplate.Name,

--- a/template_credentials.go
+++ b/template_credentials.go
@@ -40,6 +40,10 @@ var templateCredentialPrefix = "template_credentials"
 
 // <api2-generated-endpoint createTemplateCredentials>
 
+// This block is generated from Transloadit API2 contracts. If it looks wrong,
+// please report the issue instead of editing this block by hand; the source fix
+// belongs in the contract generator so all SDKs stay in sync.
+
 // CreateTemplateCredential will save the provided template credential struct to the server
 // and return the ID of the new template credential.
 func (client *Client) CreateTemplateCredential(ctx context.Context, templateCredential TemplateCredential) (string, error) {
@@ -59,6 +63,10 @@ func (client *Client) CreateTemplateCredential(ctx context.Context, templateCred
 
 // <api2-generated-endpoint getTemplateCredentials>
 
+// This block is generated from Transloadit API2 contracts. If it looks wrong,
+// please report the issue instead of editing this block by hand; the source fix
+// belongs in the contract generator so all SDKs stay in sync.
+
 // GetTemplateCredential will retrieve details about the template credential associated with the
 // provided template credential ID.
 func (client *Client) GetTemplateCredential(ctx context.Context, templateCredentialID string) (TemplateCredential, error) {
@@ -71,6 +79,10 @@ func (client *Client) GetTemplateCredential(ctx context.Context, templateCredent
 
 // <api2-generated-endpoint deleteTemplateCredentials>
 
+// This block is generated from Transloadit API2 contracts. If it looks wrong,
+// please report the issue instead of editing this block by hand; the source fix
+// belongs in the contract generator so all SDKs stay in sync.
+
 // DeleteTemplateCredential will delete the template credential associated with the provided
 // template ID.
 func (client *Client) DeleteTemplateCredential(ctx context.Context, templateCredentialID string) error {
@@ -81,6 +93,10 @@ func (client *Client) DeleteTemplateCredential(ctx context.Context, templateCred
 
 // <api2-generated-endpoint listTemplateCredentials>
 
+// This block is generated from Transloadit API2 contracts. If it looks wrong,
+// please report the issue instead of editing this block by hand; the source fix
+// belongs in the contract generator so all SDKs stay in sync.
+
 // ListTemplateCredential will retrieve all templates credential matching the criteria.
 func (client *Client) ListTemplateCredential(ctx context.Context, options *ListOptions) (list TemplateCredentialList, err error) {
 	err = client.listRequest(ctx, templateCredentialPrefix, options, &list)
@@ -90,6 +106,10 @@ func (client *Client) ListTemplateCredential(ctx context.Context, options *ListO
 // </api2-generated-endpoint listTemplateCredentials>
 
 // <api2-generated-endpoint updateTemplateCredentials>
+
+// This block is generated from Transloadit API2 contracts. If it looks wrong,
+// please report the issue instead of editing this block by hand; the source fix
+// belongs in the contract generator so all SDKs stay in sync.
 
 // UpdateTemplateCredential will update the template credential associated with the provided
 // template credential ID to match the new name and  new content.

--- a/template_credentials.go
+++ b/template_credentials.go
@@ -38,6 +38,8 @@ func NewTemplateCredential() TemplateCredential {
 
 var templateCredentialPrefix = "template_credentials"
 
+// <api2-generated-endpoint createTemplateCredentials>
+
 // CreateTemplateCredential will save the provided template credential struct to the server
 // and return the ID of the new template credential.
 func (client *Client) CreateTemplateCredential(ctx context.Context, templateCredential TemplateCredential) (string, error) {
@@ -53,6 +55,10 @@ func (client *Client) CreateTemplateCredential(ctx context.Context, templateCred
 	return response.Credential.ID, nil
 }
 
+// </api2-generated-endpoint createTemplateCredentials>
+
+// <api2-generated-endpoint getTemplateCredentials>
+
 // GetTemplateCredential will retrieve details about the template credential associated with the
 // provided template credential ID.
 func (client *Client) GetTemplateCredential(ctx context.Context, templateCredentialID string) (TemplateCredential, error) {
@@ -61,17 +67,29 @@ func (client *Client) GetTemplateCredential(ctx context.Context, templateCredent
 	return response.Credential, err
 }
 
+// </api2-generated-endpoint getTemplateCredentials>
+
+// <api2-generated-endpoint deleteTemplateCredentials>
+
 // DeleteTemplateCredential will delete the template credential associated with the provided
 // template ID.
 func (client *Client) DeleteTemplateCredential(ctx context.Context, templateCredentialID string) error {
 	return client.request(ctx, "DELETE", templateCredentialPrefix+"/"+templateCredentialID, nil, nil)
 }
 
+// </api2-generated-endpoint deleteTemplateCredentials>
+
+// <api2-generated-endpoint listTemplateCredentials>
+
 // ListTemplateCredential will retrieve all templates credential matching the criteria.
 func (client *Client) ListTemplateCredential(ctx context.Context, options *ListOptions) (list TemplateCredentialList, err error) {
 	err = client.listRequest(ctx, templateCredentialPrefix, options, &list)
 	return list, err
 }
+
+// </api2-generated-endpoint listTemplateCredentials>
+
+// <api2-generated-endpoint updateTemplateCredentials>
 
 // UpdateTemplateCredential will update the template credential associated with the provided
 // template credential ID to match the new name and  new content.
@@ -83,3 +101,5 @@ func (client *Client) UpdateTemplateCredential(ctx context.Context, templateCred
 	}
 	return client.request(ctx, "PUT", templateCredentialPrefix+"/"+templateCredentialID, content, nil)
 }
+
+// </api2-generated-endpoint updateTemplateCredentials>

--- a/template_credentials.go
+++ b/template_credentials.go
@@ -71,7 +71,7 @@ func (client *Client) CreateTemplateCredential(ctx context.Context, templateCred
 // provided template credential ID.
 func (client *Client) GetTemplateCredential(ctx context.Context, templateCredentialID string) (TemplateCredential, error) {
 	var response templateCredentialResponseBody
-	err := client.request(ctx, "GET", templateCredentialPrefix+"/"+templateCredentialID, nil, &response)
+	err := client.request(ctx, "GET", templateCredentialPrefix+"/"+escapePathSegment(templateCredentialID), nil, &response)
 	return response.Credential, err
 }
 
@@ -86,7 +86,7 @@ func (client *Client) GetTemplateCredential(ctx context.Context, templateCredent
 // DeleteTemplateCredential will delete the template credential associated with the provided
 // template ID.
 func (client *Client) DeleteTemplateCredential(ctx context.Context, templateCredentialID string) error {
-	return client.request(ctx, "DELETE", templateCredentialPrefix+"/"+templateCredentialID, nil, nil)
+	return client.request(ctx, "DELETE", templateCredentialPrefix+"/"+escapePathSegment(templateCredentialID), nil, nil)
 }
 
 // </api2-generated-endpoint deleteTemplateCredentials>
@@ -119,7 +119,7 @@ func (client *Client) UpdateTemplateCredential(ctx context.Context, templateCred
 		"type":    templateCredential.Type,
 		"content": templateCredential.Content,
 	}
-	return client.request(ctx, "PUT", templateCredentialPrefix+"/"+templateCredentialID, content, nil)
+	return client.request(ctx, "PUT", templateCredentialPrefix+"/"+escapePathSegment(templateCredentialID), content, nil)
 }
 
 // </api2-generated-endpoint updateTemplateCredentials>

--- a/template_credentials.go
+++ b/template_credentials.go
@@ -70,6 +70,10 @@ func (client *Client) CreateTemplateCredential(ctx context.Context, templateCred
 // GetTemplateCredential will retrieve details about the template credential associated with the
 // provided template credential ID.
 func (client *Client) GetTemplateCredential(ctx context.Context, templateCredentialID string) (TemplateCredential, error) {
+	if err := validatePathSegment(templateCredentialID); err != nil {
+		return TemplateCredential{}, err
+	}
+
 	var response templateCredentialResponseBody
 	err := client.request(ctx, "GET", templateCredentialPrefix+"/"+escapePathSegment(templateCredentialID), nil, &response)
 	return response.Credential, err
@@ -86,6 +90,10 @@ func (client *Client) GetTemplateCredential(ctx context.Context, templateCredent
 // DeleteTemplateCredential will delete the template credential associated with the provided
 // template ID.
 func (client *Client) DeleteTemplateCredential(ctx context.Context, templateCredentialID string) error {
+	if err := validatePathSegment(templateCredentialID); err != nil {
+		return err
+	}
+
 	return client.request(ctx, "DELETE", templateCredentialPrefix+"/"+escapePathSegment(templateCredentialID), nil, nil)
 }
 
@@ -114,6 +122,10 @@ func (client *Client) ListTemplateCredential(ctx context.Context, options *ListO
 // UpdateTemplateCredential will update the template credential associated with the provided
 // template credential ID to match the new name and  new content.
 func (client *Client) UpdateTemplateCredential(ctx context.Context, templateCredentialID string, templateCredential TemplateCredential) error {
+	if err := validatePathSegment(templateCredentialID); err != nil {
+		return err
+	}
+
 	content := map[string]interface{}{
 		"name":    templateCredential.Name,
 		"type":    templateCredential.Type,

--- a/template_test.go
+++ b/template_test.go
@@ -2,9 +2,34 @@ package transloadit
 
 import (
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"reflect"
 	"testing"
 )
+
+func TestGetTemplateRejectsDotPathSegments(t *testing.T) {
+	for _, segment := range []string{".", ".."} {
+		t.Run(segment, func(t *testing.T) {
+			requested := false
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				requested = true
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{}`))
+			}))
+			defer server.Close()
+
+			client := NewClient(Config{AuthKey: "key", AuthSecret: "secret", Endpoint: server.URL})
+			_, err := client.GetTemplate(ctx, segment)
+			if err == nil {
+				t.Error("expected a dot path segment error")
+			}
+			if requested {
+				t.Error("sent a request for a dot path segment")
+			}
+		})
+	}
+}
 
 func TestTemplate(t *testing.T) {
 	t.Parallel()

--- a/token.go
+++ b/token.go
@@ -1,0 +1,81 @@
+// Code generated from Transloadit API2 contracts; DO NOT EDIT.
+// If it looks wrong, please report the issue instead of editing this file by hand;
+// the source fix belongs in the contract generator so all SDKs stay in sync.
+
+package transloadit
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+type BearerTokenOptions struct {
+	Aud   string `json:"aud,omitempty"`
+	Scope string `json:"scope,omitempty"`
+}
+
+type BearerTokenResponse struct {
+	AccessToken string `json:"access_token"`
+	ExpiresIn   int    `json:"expires_in"`
+	Scope       string `json:"scope"`
+	TokenType   string `json:"token_type"`
+}
+
+func (client *Client) IssueBearerToken(ctx context.Context, options BearerTokenOptions) (BearerTokenResponse, error) {
+	form := url.Values{}
+	if options.Aud != "" {
+		form.Set("aud", options.Aud)
+	}
+	form.Set("grant_type", "client_credentials")
+	if options.Scope != "" {
+		form.Set("scope", options.Scope)
+	}
+
+	endpoint := strings.TrimRight(client.config.Endpoint, "/") + "/token"
+	endpointURL, err := url.Parse(endpoint)
+	if err != nil {
+		return BearerTokenResponse{}, fmt.Errorf("parse bearer token endpoint: %w", err)
+	}
+	loopback := endpointURL.Hostname() == "localhost" || endpointURL.Hostname() == "::1" || strings.HasPrefix(endpointURL.Hostname(), "127.")
+	if endpointURL.User != nil || (endpointURL.Scheme != "https" && !(endpointURL.Scheme == "http" && loopback)) {
+		return BearerTokenResponse{}, fmt.Errorf("refusing to send credentials to bearer token endpoint %q", endpointURL.Redacted())
+	}
+	request, err := http.NewRequestWithContext(ctx, "POST", endpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return BearerTokenResponse{}, fmt.Errorf("create bearer token request: %w", err)
+	}
+	request.SetBasicAuth(client.config.AuthKey, client.config.AuthSecret)
+	request.Header.Set("Accept", "application/json")
+	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	request.Header.Set("Transloadit-Client", "go-sdk:"+Version)
+
+	httpClient := *client.httpClient
+	httpClient.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	response, err := httpClient.Do(request)
+	if err != nil {
+		return BearerTokenResponse{}, fmt.Errorf("issue bearer token: %w", err)
+	}
+	defer response.Body.Close()
+
+	body := io.LimitReader(response.Body, 128*1024*1024)
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		var requestError RequestError
+		if err := json.NewDecoder(body).Decode(&requestError); err != nil {
+			return BearerTokenResponse{}, fmt.Errorf("decode bearer token error: %w", err)
+		}
+		return BearerTokenResponse{}, requestError
+	}
+
+	var token BearerTokenResponse
+	if err := json.NewDecoder(body).Decode(&token); err != nil {
+		return BearerTokenResponse{}, fmt.Errorf("decode bearer token response: %w", err)
+	}
+	return token, nil
+}

--- a/token.go
+++ b/token.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -41,7 +42,9 @@ func (client *Client) IssueBearerToken(ctx context.Context, options BearerTokenO
 	if err != nil {
 		return BearerTokenResponse{}, fmt.Errorf("parse bearer token endpoint: %w", err)
 	}
-	loopback := endpointURL.Hostname() == "localhost" || endpointURL.Hostname() == "::1" || strings.HasPrefix(endpointURL.Hostname(), "127.")
+	hostname := endpointURL.Hostname()
+	ip := net.ParseIP(hostname)
+	loopback := hostname == "localhost" || (ip != nil && ip.IsLoopback())
 	if endpointURL.User != nil || (endpointURL.Scheme != "https" && !(endpointURL.Scheme == "http" && loopback)) {
 		return BearerTokenResponse{}, fmt.Errorf("refusing to send credentials to bearer token endpoint %q", endpointURL.Redacted())
 	}

--- a/token_test.go
+++ b/token_test.go
@@ -1,0 +1,82 @@
+package transloadit
+
+import (
+	"context"
+	"encoding/base64"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+func TestIssueBearerToken(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		if request.Method != http.MethodPost || request.URL.Path != "/token" {
+			t.Errorf("expected POST /token, got %s %s", request.Method, request.URL.Path)
+		}
+		expectedAuthorization := "Basic " + base64.StdEncoding.EncodeToString([]byte("key:secret"))
+		if request.Header.Get("Authorization") != expectedAuthorization {
+			t.Errorf("unexpected Authorization header %q", request.Header.Get("Authorization"))
+		}
+		if request.Header.Get("Content-Type") != "application/x-www-form-urlencoded" {
+			t.Errorf("unexpected Content-Type %q", request.Header.Get("Content-Type"))
+		}
+		body, err := io.ReadAll(request.Body)
+		if err != nil {
+			t.Errorf("read token request: %v", err)
+		}
+		form, err := url.ParseQuery(string(body))
+		if err != nil {
+			t.Errorf("parse token request: %v", err)
+		}
+		if form.Get("grant_type") != "client_credentials" || form.Get("scope") != "assemblies:read" {
+			t.Errorf("unexpected token form %q", form.Encode())
+		}
+		if _, present := form["aud"]; present {
+			t.Errorf("aud should be omitted, got %q", form.Get("aud"))
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"access_token":"abc","expires_in":21600,"scope":"assemblies:read","token_type":"Bearer"}`)
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{AuthKey: "key", AuthSecret: "secret", Endpoint: server.URL})
+	token, err := client.IssueBearerToken(
+		context.Background(),
+		BearerTokenOptions{Scope: "assemblies:read"},
+	)
+	if err != nil {
+		t.Fatalf("IssueBearerToken failed: %v", err)
+	}
+	if token.AccessToken != "abc" || token.ExpiresIn != 21600 || token.TokenType != "Bearer" {
+		t.Fatalf("unexpected token response: %#v", token)
+	}
+}
+
+func TestIssueBearerTokenDoesNotFollowRedirects(t *testing.T) {
+	t.Parallel()
+
+	redirected := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, request *http.Request) {
+		if request.URL.Path == "/redirected" {
+			redirected = true
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		http.Redirect(w, request, "/redirected", http.StatusFound)
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{AuthKey: "key", AuthSecret: "secret", Endpoint: server.URL})
+	_, err := client.IssueBearerToken(context.Background(), BearerTokenOptions{})
+	if err == nil {
+		t.Fatal("IssueBearerToken should reject a redirect response")
+	}
+	if redirected {
+		t.Fatal("IssueBearerToken followed a redirect with Basic credentials")
+	}
+}

--- a/token_test.go
+++ b/token_test.go
@@ -10,6 +10,12 @@ import (
 	"testing"
 )
 
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return fn(request)
+}
+
 func TestIssueBearerToken(t *testing.T) {
 	t.Parallel()
 
@@ -78,5 +84,28 @@ func TestIssueBearerTokenDoesNotFollowRedirects(t *testing.T) {
 	}
 	if redirected {
 		t.Fatal("IssueBearerToken followed a redirect with Basic credentials")
+	}
+}
+
+func TestIssueBearerTokenRejects127PrefixedDomain(t *testing.T) {
+	t.Parallel()
+
+	requested := false
+	client := NewClient(Config{
+		AuthKey:    "key",
+		AuthSecret: "secret",
+		Endpoint:   "http://127.attacker.com",
+	})
+	client.httpClient.Transport = roundTripFunc(func(*http.Request) (*http.Response, error) {
+		requested = true
+		return nil, nil
+	})
+
+	_, err := client.IssueBearerToken(context.Background(), BearerTokenOptions{})
+	if err == nil {
+		t.Fatal("IssueBearerToken should reject a 127-prefixed domain")
+	}
+	if requested {
+		t.Fatal("IssueBearerToken sent credentials to a 127-prefixed domain")
 	}
 }

--- a/transloadit.go
+++ b/transloadit.go
@@ -399,7 +399,14 @@ func (client *Client) requestAssemblyURL(ctx context.Context, method string, ass
 		return fmt.Errorf("request: %s", err)
 	}
 
-	return client.doRequest(req, result)
+	requestClient := *client
+	httpClient := *client.httpClient
+	httpClient.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	requestClient.httpClient = &httpClient
+
+	return requestClient.doRequest(req, result)
 }
 
 // </api2-generated-endpoint assemblyUrlRequestSupport>

--- a/transloadit.go
+++ b/transloadit.go
@@ -158,37 +158,6 @@ func (client *Client) request(ctx context.Context, method string, path string, c
 	return client.requestWithFormFields(ctx, method, path, content, nil, result)
 }
 
-func (client *Client) requestAssemblyURL(ctx context.Context, method string, assemblyURL string, result interface{}) error {
-	candidate, err := url.Parse(assemblyURL)
-	if err != nil || !candidate.IsAbs() || candidate.User != nil {
-		return fmt.Errorf("untrusted Assembly URL: %s", assemblyURL)
-	}
-
-	configured, err := url.Parse(client.config.Endpoint)
-	if err != nil {
-		return fmt.Errorf("invalid configured endpoint: %s", err)
-	}
-
-	sameOrigin := strings.EqualFold(candidate.Scheme, configured.Scheme) &&
-		strings.EqualFold(candidate.Hostname(), configured.Hostname()) &&
-		candidate.Port() == configured.Port()
-	hostname := strings.ToLower(candidate.Hostname())
-	isTransloaditAPI2Cell := strings.EqualFold(candidate.Scheme, "https") &&
-		(candidate.Port() == "" || candidate.Port() == "443") &&
-		strings.HasPrefix(hostname, "api2-") &&
-		strings.HasSuffix(hostname, ".transloadit.com")
-	if !sameOrigin && !isTransloaditAPI2Cell {
-		return fmt.Errorf("untrusted Assembly URL: %s", assemblyURL)
-	}
-
-	req, err := http.NewRequestWithContext(ctx, method, assemblyURL, nil)
-	if err != nil {
-		return fmt.Errorf("request: %s", err)
-	}
-
-	return client.doRequest(req, result)
-}
-
 func formFieldValue(value interface{}) string {
 	switch typed := value.(type) {
 	case nil:
@@ -391,3 +360,46 @@ func (client *Client) GetBillForInvoice(ctx context.Context, month string, invoi
 }
 
 // </api2-generated-endpoint getBillForInvoice>
+
+// <api2-generated-endpoint assemblyUrlRequestSupport>
+
+// This block is generated from Transloadit API2 contracts. If it looks wrong,
+// please report the issue instead of editing this block by hand; the source fix
+// belongs in the contract generator so all SDKs stay in sync.
+
+func (client *Client) requestAssemblyURL(ctx context.Context, method string, assemblyURL string, result interface{}) error {
+	candidate, err := url.Parse(assemblyURL)
+	if err != nil || !candidate.IsAbs() || candidate.User != nil {
+		return fmt.Errorf("untrusted Assembly URL: %s", assemblyURL)
+	}
+
+	configured, err := url.Parse(client.config.Endpoint)
+	if err != nil {
+		return fmt.Errorf("invalid configured endpoint: %s", err)
+	}
+
+	sameOrigin := strings.EqualFold(candidate.Scheme, configured.Scheme) &&
+		strings.EqualFold(candidate.Hostname(), configured.Hostname()) &&
+		candidate.Port() == configured.Port()
+	sameHTTPSHost := strings.EqualFold(candidate.Scheme, "https") &&
+		(candidate.Port() == "" || candidate.Port() == "443") &&
+		candidate.Hostname() != "" &&
+		strings.EqualFold(candidate.Hostname(), configured.Hostname())
+	hostname := strings.ToLower(candidate.Hostname())
+	isTransloaditAPI2Cell := strings.EqualFold(candidate.Scheme, "https") &&
+		(candidate.Port() == "" || candidate.Port() == "443") &&
+		strings.HasPrefix(hostname, "api2-") &&
+		strings.HasSuffix(hostname, ".transloadit.com")
+	if !sameOrigin && !sameHTTPSHost && !isTransloaditAPI2Cell {
+		return fmt.Errorf("untrusted Assembly URL: %s", assemblyURL)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, assemblyURL, nil)
+	if err != nil {
+		return fmt.Errorf("request: %s", err)
+	}
+
+	return client.doRequest(req, result)
+}
+
+// </api2-generated-endpoint assemblyUrlRequestSupport>

--- a/transloadit.go
+++ b/transloadit.go
@@ -155,6 +155,32 @@ func (client *Client) doRequest(req *http.Request, result interface{}) error {
 }
 
 func (client *Client) request(ctx context.Context, method string, path string, content map[string]interface{}, result interface{}) error {
+	return client.requestWithFormFields(ctx, method, path, content, nil, result)
+}
+
+func formFieldValue(value interface{}) string {
+	switch typed := value.(type) {
+	case nil:
+		return ""
+	case bool:
+		return strconv.FormatBool(typed)
+	case float32:
+		return strconv.FormatFloat(float64(typed), 'f', -1, 32)
+	case float64:
+		return strconv.FormatFloat(typed, 'f', -1, 64)
+	case string:
+		return typed
+	}
+
+	serialized, err := json.Marshal(value)
+	if err == nil {
+		return string(serialized)
+	}
+
+	return fmt.Sprint(value)
+}
+
+func (client *Client) requestWithFormFields(ctx context.Context, method string, path string, content map[string]interface{}, formFields map[string]interface{}, result interface{}) error {
 	uri := path
 	// Don't add host for absolute urls
 	if u, err := url.Parse(path); err == nil && u.Scheme == "" {
@@ -175,6 +201,9 @@ func (client *Client) request(ctx context.Context, method string, path string, c
 	v := url.Values{}
 	v.Set("params", params)
 	v.Set("signature", signature)
+	for name, value := range formFields {
+		v.Set(name, formFieldValue(value))
+	}
 
 	var body io.Reader
 	if method == "GET" {

--- a/transloadit.go
+++ b/transloadit.go
@@ -340,6 +340,10 @@ func (client *Client) CreateSignedSmartCDNUrl(opts SignedSmartCDNUrlOptions) str
 // belongs in the contract generator so all SDKs stay in sync.
 
 func (client *Client) GetBill(ctx context.Context, month string) (map[string]interface{}, error) {
+	if err := validatePathSegment(month); err != nil {
+		return nil, err
+	}
+
 	var bill map[string]interface{}
 	err := client.request(ctx, "GET", "bill/"+escapePathSegment(month), nil, &bill)
 	return bill, err
@@ -354,6 +358,13 @@ func (client *Client) GetBill(ctx context.Context, month string) (map[string]int
 // belongs in the contract generator so all SDKs stay in sync.
 
 func (client *Client) GetBillForInvoice(ctx context.Context, month string, invoiceID string) (map[string]interface{}, error) {
+	if err := validatePathSegment(month); err != nil {
+		return nil, err
+	}
+	if err := validatePathSegment(invoiceID); err != nil {
+		return nil, err
+	}
+
 	var bill map[string]interface{}
 	err := client.request(ctx, "GET", "bill/"+escapePathSegment(month)+"/"+escapePathSegment(invoiceID), nil, &bill)
 	return bill, err

--- a/transloadit.go
+++ b/transloadit.go
@@ -372,7 +372,7 @@ func (client *Client) CreateSignedSmartCDNUrl(opts SignedSmartCDNUrlOptions) str
 
 func (client *Client) GetBill(ctx context.Context, month string) (map[string]interface{}, error) {
 	var bill map[string]interface{}
-	err := client.request(ctx, "GET", "bill/"+month, nil, &bill)
+	err := client.request(ctx, "GET", "bill/"+escapePathSegment(month), nil, &bill)
 	return bill, err
 }
 
@@ -386,7 +386,7 @@ func (client *Client) GetBill(ctx context.Context, month string) (map[string]int
 
 func (client *Client) GetBillForInvoice(ctx context.Context, month string, invoiceID string) (map[string]interface{}, error) {
 	var bill map[string]interface{}
-	err := client.request(ctx, "GET", "bill/"+month+"/"+invoiceID, nil, &bill)
+	err := client.request(ctx, "GET", "bill/"+escapePathSegment(month)+"/"+escapePathSegment(invoiceID), nil, &bill)
 	return bill, err
 }
 

--- a/transloadit.go
+++ b/transloadit.go
@@ -332,3 +332,31 @@ func (client *Client) CreateSignedSmartCDNUrl(opts SignedSmartCDNUrlOptions) str
 
 	return signedURL
 }
+
+// <api2-generated-endpoint getBill>
+
+// This block is generated from Transloadit API2 contracts. If it looks wrong,
+// please report the issue instead of editing this block by hand; the source fix
+// belongs in the contract generator so all SDKs stay in sync.
+
+func (client *Client) GetBill(ctx context.Context, month string) (map[string]interface{}, error) {
+	var bill map[string]interface{}
+	err := client.request(ctx, "GET", "bill/"+month, nil, &bill)
+	return bill, err
+}
+
+// </api2-generated-endpoint getBill>
+
+// <api2-generated-endpoint getBillForInvoice>
+
+// This block is generated from Transloadit API2 contracts. If it looks wrong,
+// please report the issue instead of editing this block by hand; the source fix
+// belongs in the contract generator so all SDKs stay in sync.
+
+func (client *Client) GetBillForInvoice(ctx context.Context, month string, invoiceID string) (map[string]interface{}, error) {
+	var bill map[string]interface{}
+	err := client.request(ctx, "GET", "bill/"+month+"/"+invoiceID, nil, &bill)
+	return bill, err
+}
+
+// </api2-generated-endpoint getBillForInvoice>

--- a/transloadit.go
+++ b/transloadit.go
@@ -158,6 +158,37 @@ func (client *Client) request(ctx context.Context, method string, path string, c
 	return client.requestWithFormFields(ctx, method, path, content, nil, result)
 }
 
+func (client *Client) requestAssemblyURL(ctx context.Context, method string, assemblyURL string, result interface{}) error {
+	candidate, err := url.Parse(assemblyURL)
+	if err != nil || !candidate.IsAbs() || candidate.User != nil {
+		return fmt.Errorf("untrusted Assembly URL: %s", assemblyURL)
+	}
+
+	configured, err := url.Parse(client.config.Endpoint)
+	if err != nil {
+		return fmt.Errorf("invalid configured endpoint: %s", err)
+	}
+
+	sameOrigin := strings.EqualFold(candidate.Scheme, configured.Scheme) &&
+		strings.EqualFold(candidate.Hostname(), configured.Hostname()) &&
+		candidate.Port() == configured.Port()
+	hostname := strings.ToLower(candidate.Hostname())
+	isTransloaditAPI2Cell := strings.EqualFold(candidate.Scheme, "https") &&
+		(candidate.Port() == "" || candidate.Port() == "443") &&
+		strings.HasPrefix(hostname, "api2-") &&
+		strings.HasSuffix(hostname, ".transloadit.com")
+	if !sameOrigin && !isTransloaditAPI2Cell {
+		return fmt.Errorf("untrusted Assembly URL: %s", assemblyURL)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, assemblyURL, nil)
+	if err != nil {
+		return fmt.Errorf("request: %s", err)
+	}
+
+	return client.doRequest(req, result)
+}
+
 func formFieldValue(value interface{}) string {
 	switch typed := value.(type) {
 	case nil:

--- a/transloadit_test.go
+++ b/transloadit_test.go
@@ -52,6 +52,29 @@ func TestNewClient_Success(t *testing.T) {
 	_ = NewClient(config)
 }
 
+func TestFormFieldValue(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		input    interface{}
+		expected string
+	}{
+		"bool":   {input: true, expected: "true"},
+		"int":    {input: 3, expected: "3"},
+		"nil":    {input: nil, expected: ""},
+		"object": {input: map[string]interface{}{"field": "value"}, expected: `{"field":"value"}`},
+		"string": {input: "file", expected: "file"},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if actual := formFieldValue(tc.input); actual != tc.expected {
+				t.Fatalf("expected %q, got %q", tc.expected, actual)
+			}
+		})
+	}
+}
+
 func setup(t *testing.T) Client {
 	config := DefaultConfig
 	config.AuthKey = os.Getenv("TRANSLOADIT_KEY")

--- a/wait.go
+++ b/wait.go
@@ -5,6 +5,8 @@ import (
 	"time"
 )
 
+// <api2-generated-feature waitForAssembly>
+
 // WaitForAssembly fetches continuously the assembly status until it has
 // finished uploading and executing or until an assembly error occurs.
 // If you want to end this loop prematurely, you can cancel the supplied context.
@@ -33,3 +35,5 @@ func (client *Client) WaitForAssembly(ctx context.Context, assembly *AssemblyInf
 		}
 	}
 }
+
+// </api2-generated-feature waitForAssembly>

--- a/wait.go
+++ b/wait.go
@@ -7,6 +7,10 @@ import (
 
 // <api2-generated-feature waitForAssembly>
 
+// This block is generated from Transloadit API2 contracts. If it looks wrong,
+// please report the issue instead of editing this block by hand; the source fix
+// belongs in the contract generator so all SDKs stay in sync.
+
 // WaitForAssembly fetches continuously the assembly status until it has
 // finished uploading and executing or until an assembly error occurs.
 // If you want to end this loop prematurely, you can cancel the supplied context.

--- a/wait.go
+++ b/wait.go
@@ -11,9 +11,8 @@ import (
 // please report the issue instead of editing this block by hand; the source fix
 // belongs in the contract generator so all SDKs stay in sync.
 
-// WaitForAssembly fetches continuously the assembly status until it has
-// finished uploading and executing or until an assembly error occurs.
-// If you want to end this loop prematurely, you can cancel the supplied context.
+// WaitForAssembly waits for an Assembly to finish uploading and executing.
+// Use the returned assembly_ssl_url as the assembly URL.
 func (client *Client) WaitForAssembly(ctx context.Context, assembly *AssemblyInfo) (*AssemblyInfo, error) {
 	for {
 		res, err := client.GetAssembly(ctx, assembly.AssemblySSLURL)


### PR DESCRIPTION
## Why

API2 is becoming the source of truth for endpoint contracts and SDK generation. This Go SDK companion proves two things cautiously: API2 can delete/rewrite generated Go regions without behavior drift, and checked-in Go examples can exercise that generated surface against devdock as normal consumer code.

## Experimental Status

Experimental work: this PR is part of the API2 contract/generated SDK effort and is intentionally kept as a Draft while the generated surface and consumer proof examples are validated.

## What changed

- Added API2 generated-region markers around existing Go SDK endpoint methods: Assembly status/cancel/list, Assembly notification replay, Template create/get/update/delete/list, and Template Credential create/get/update/delete/list.
- Added generated high-level feature methods including `Client.CreateTusAssembly()` and `Client.WaitForAssembly()` coverage through API2's generator.
- Added generated model conformance guard coverage for `AssemblyInfo` / `FileInfo` fields that the contract says SDK examples need.
- Added checked-in, hand-written devdock examples for TUS Assembly upload, Template lifecycle, and Assembly lifecycle.
- The new Assembly lifecycle example proves `CreateTusAssembly`, `GetAssembly`, `ListAssemblies`, and `CancelAssembly` together against API2 devdock using contract-injected scenario JSON.
- The generated regions are owned by API2 contracts; fixes should land in API2 and be regenerated here.
- The examples are deliberately not generated: they are idiomatic consumer proofs. API2 injects scenario JSON and validates the results.

## Verification

- From API2: `api2/bin/cli.ts contracts sdks --no-motd --target transloadit --platform go --sdk-root ../go-sdk --compare-existing`
- From API2: `core/bin/devdock.ts exec tstrun system/sdk_examples/go-transloadit-examples.test.ts -vv --max-time-per-test 600`
- Go SDK: `go test ./examples/api2-devdock-assembly-lifecycle ./examples/api2-devdock-tus-assembly ./examples/api2-devdock-template-lifecycle`
- Go SDK: `go test ./... -run 'Test(NewClient|FormFieldValue|AssemblyInfo_TusFields)'`

## Notes

Full `go test ./...` still expects live `TRANSLOADIT_KEY`/`TRANSLOADIT_SECRET` for integration-style tests. I left those untouched and ran the credential-free subset plus API2's devdock system example lane.

## Companion PRs

### Transloadit

- API2 contract/generator source: https://github.com/transloadit/api2/pull/7928
- Content generated endpoint docs: https://github.com/transloadit/content/pull/5074
- Python SDK generated endpoints: https://github.com/transloadit/python-sdk/pull/57
- Node SDK generated markers: https://github.com/transloadit/node-sdk/pull/422
- Java SDK generated endpoint markers: https://github.com/transloadit/java-sdk/pull/101

### TUS

Allowed outward links from Transloadit to the related tus companion PRs:

- tus-js-client: https://github.com/tus/tus-js-client/pull/872
- tus-go-client: https://github.com/tus/tus-go-client/pull/6
- tus-py-client: https://github.com/tus/tus-py-client/pull/114
- tus-java-client: https://github.com/tus/tus-java-client/pull/149
- tus-android-client: https://github.com/tus/tus-android-client/pull/167
