### PR TITLE
Pin third-party GitHub Actions to SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         TRANSLOADIT_SECRET: ${{ secrets.TRANSLOADIT_SECRET }}
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v6
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f
       with:
         fail_ci_if_error: true
         files: ./coverage.out


### PR DESCRIPTION
Why:

Third-party GitHub Action tags can move after review. Pinning these references to full commit SHAs makes the workflow supply-chain input immutable and prepares the repo for stricter GitHub Actions allowlist policy.

What:

- Replaced floating third-party action refs with the commits they currently resolve to.
- Left first-party, GitHub-owned, and already SHA-pinned actions unchanged.

Changed workflows:

- `.github/workflows/ci.yml`

Resolved refs:

- `codecov/codecov-action@v6` -> `codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f`

Verification:

- `git diff --check`
- Ruby YAML parse for changed workflow files
- Confirmed replaced floating refs no longer appear in changed workflows
